### PR TITLE
Shorten app desc which goes to the code server

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,8 @@ defmodule Hound.Mixfile do
   def application do
     [
       applications: [:jsex, :ibrowse],
-      mod: { Hound, [] }
+      mod: { Hound, [] },
+      description: 'Browser automation library',
     ]
   end
 


### PR DESCRIPTION
Elixir apps have actually 2 descriptions:
- Package description. This can be short or long, as you prefer. This one goes to Hex
- app description which lands in ...app.src file and is visible in the code server (try `:application.which_applications`). This one should be very short.

Now Mix copies the package description into app description if the latter was not present, resulting in having it overly long. 
Please see an example (scroll Hounds desc to the right):

``` Elixir
iex(1)> :application.which_applications
[{:fboy, 'fboy', '0.0.1'},
 {:hound,
  'Elixir library for browser automation and writing integration tests in Elixir.\n\n## Features\n\n* Can run __multiple browser sessions__ simultaneously. [See example](https://github.com/HashNuke/hound/blob/master/test/multiple_browser_session_test.exs).\n\n* Supports Selenium (Firefox, Chrome), ChromeDriver and PhantomJs.\n\n* Supports Javascript-heavy apps. Retries a few times before reporting error.\n\n* Implements the WebDriver Wire Protocol.\n\n\n**Internet Explorer may work under Selenium, but hasn\'t been tested.\n',
  '0.5.8'}, {:jsex, 'json for elixir\n', '2.0.0'},
 {:jsx, 'a streaming, evented json parsing toolkit', '2.0.4'},
 {:ibrowse, 'Erlang HTTP client application', '4.0.2'},
 {:logger, 'logger', '0.15.1'}, {:inets, 'INETS  CXC 138 49', '5.10.2'},
 {:ssl, 'Erlang/OTP SSL application', '5.3.5'},
 {:public_key, 'Public key infrastructure', '0.22'},
 {:asn1, 'The Erlang ASN1 compiler version 3.0.1', '3.0.1'},
 {:mix, 'mix', '0.15.1'}, {:iex, 'iex', '0.15.1'},
 {:elixir, 'elixir', '0.15.1'}, {:syntax_tools, 'Syntax tools', '1.6.15'},
 {:compiler, 'ERTS  CXC 138 10', '5.0.1'}, {:crypto, 'CRYPTO', '3.4'},
 {:stdlib, 'ERTS  CXC 138 10', '2.1'}, {:kernel, 'ERTS  CXC 138 10', '3.0.1'}]
```

I was talking about this with Eric once, but this is not fixed/rethought yet.

So this commit fixes the short desc for your app.
