### PR TITLE
Add visible page text

### DIFF
--- a/lib/hound/helpers/page.ex
+++ b/lib/hound/helpers/page.ex
@@ -10,6 +10,13 @@ defmodule Hound.Helpers.Page do
     make_req(:get, "session/#{session_id}/source")
   end
 
+  @doc "Gets the visible text of current page."
+  @spec visible_page_text() :: String.t
+  def visible_page_text do
+    element_id = find_element(:css, "body")
+    session_id = Hound.current_session_id
+    make_req(:get, "session/#{session_id}/element/#{element_id}/text")
+  end
 
   @doc "Gets the title of the current page."
   @spec page_title() :: String.t

--- a/test/helpers/page_test.exs
+++ b/test/helpers/page_test.exs
@@ -9,6 +9,12 @@ defmodule PageTest do
     assert(Regex.match?(~r/DOCTYPE/, page_source))
   end
 
+  test "should get visible page text" do
+    navigate_to("http://localhost:9090/page1.html")
+    assert(String.contains? visible_page_text, "Flying")
+    assert(not String.contains? visible_page_text, "This is hidden")
+  end
+
 
   test "should get page title" do
     navigate_to("http://localhost:9090/page1.html")


### PR DESCRIPTION
I thought it was a good idea to be able to get the text that is visible text on the page directly. This is useful for TDD. 

Currently, I've been writing code that looks like this: 

```
  expect(page_source).to have_text("Welcome")
```

But the test would be more accurate if I was able to write this: 
```
  expect(visible_page_text).to have_text("Welcome")
```

That way, code like this won't return false positives: 
```
<html>
...
  <body>
    <div id="welcome">
      hey!
    </div>
  </body>
</html>
```