### PR TITLE
Update README.md with link to docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 For browser automation and writing integration tests in Elixir.
 
-<a href="http://github.com/HashNuke/Hound" target="_parent">Source</a> | <a href="http://hexdocs.pm/hound" target="_parent">Documentation</a>
+<a href="http://github.com/HashNuke/Hound" target="_parent">Source</a> | <a href="http://hashnuke.com/docs/hound/" target="_parent">Documentation</a>
 
 [![Build Status](https://travis-ci.org/HashNuke/hound.png?branch=master)](https://travis-ci.org/HashNuke/hound)
 


### PR DESCRIPTION
The documentation link to dexdocs in the README wouldn't load and locked up the tab. This link goes to the hound docs on http://hashnuke.com/.