### PR TITLE
Add has_class? helper

### DIFF
--- a/lib/hound/helpers/element.ex
+++ b/lib/hound/helpers/element.ex
@@ -165,6 +165,23 @@ defmodule Hound.Helpers.Element do
 
 
   @doc """
+  Checks if an element has a given class.
+
+      element_id = find_element(:class, "another_example")
+      has_class?(element_id, "another_class")
+
+  You can also pass the selector as a tuple, for the first argument
+
+      has_class?({:class, "another_example"}, "another_class")
+  """
+  @spec has_class?(element, String.t) :: :true | :false
+  def has_class?(element, class) do
+    class_attribute = attribute_value(element, "class")
+    String.split(class_attribute) |> Enum.member?(class)
+  end
+
+
+  @doc """
   Checks if two element IDs refer to the same DOM element.
 
       element_id1 = find_element(:name, "username")

--- a/test/helpers/element_with_selectors_test.exs
+++ b/test/helpers/element_with_selectors_test.exs
@@ -85,6 +85,20 @@ defmodule ElementWithSelectorsTest do
   end
 
 
+  test "should return true when an element has a class, when selector is passed" do
+    navigate_to "http://localhost:9090/page1.html"
+    assert has_class?({:class, "example"}, "example")
+    assert has_class?({:class, "another_example"}, "another_class")
+  end
+
+
+  test "should return false when an element does not have a class, when selector is passed" do
+    navigate_to "http://localhost:9090/page1.html"
+    refute has_class?({:class, "example"}, "ex")
+    refute has_class?({:class, "example"}, "other")
+  end
+
+
   test "should return true if an element is displayed, when selector is passed" do
     navigate_to "http://localhost:9090/page1.html"
     assert element_displayed?({:class, "example"})

--- a/test/sample_pages/page1.html
+++ b/test/sample_pages/page1.html
@@ -20,7 +20,7 @@
 <body>
   <div class="container">
     <p class="example" data-greeting="hello">Paragraph</p>
-    <p class="another_example">Another Paragraph</p>
+    <p class="another_example another_class">Another Paragraph</p>
   </div>
 
   <div class="hidden-element">This is hidden</div>


### PR DESCRIPTION
Hey, what do you think of my suggestion of adding a `has_class?` helper? I could use it in a situation like [this](https://github.com/backspace/adventure-registrations/blob/57dea41246a14e001e7fa33926b1162120250648/test/support/pages/details.ex#L18-L19); I want to check whether an element has a particular CSS class, so I’m doing:

    String.contains?(attribute_value(selector, "class"), "a-class")

It would be great if I could just do this:

    has_class?(selector, "a-class")