### PR TITLE
set_cookie accepts Map, not Dict

### DIFF
--- a/lib/hound/helpers/cookie.ex
+++ b/lib/hound/helpers/cookie.ex
@@ -18,10 +18,10 @@ defmodule Hound.Helpers.Cookie do
   @doc """
   Sets cookie.
 
-      set_cookie([name: "cart_id", value: 123213])
-      set_cookie([name: "cart_id", value: "23fa0ev5a6er", secure: true])
+      set_cookie(%{name: "cart_id", value: 123213})
+      set_cookie(%{name: "cart_id", value: "23fa0ev5a6er", secure: true})
 
-  Accepts a ListDict with the following keys:
+  Accepts a Map with the following keys:
 
   * name (string) - REQUIRED
   * value (string) - REQUIRED
@@ -30,7 +30,7 @@ defmodule Hound.Helpers.Cookie do
   * secure (boolean)
   * expiry (integer, specified in seconds since midnight, January 1, 1970 UTC)
   """
-  @spec set_cookie(Dict.t) :: :ok
+  @spec set_cookie(Map.t) :: :ok
   def set_cookie(cookie) do
     session_id = Hound.current_session_id
     make_req(:post, "session/#{session_id}/cookie", %{cookie: cookie})


### PR DESCRIPTION
Hi there - 

I was unable to set a cookie using the docs example of a ListDict:

```
iex(37)> Hound.Helpers.Cookie.set_cookie([name: "blah", value: "blah"]) 
** (Poison.EncodeError) unable to encode value: {:value, "blah"}
    (poison) lib/poison/encoder.ex:339: Poison.Encoder.Any.encode/2
    (poison) lib/poison/encoder.ex:232: anonymous fn/3 in Poison.Encoder.List.encode/3
    (poison) lib/poison/encoder.ex:233: Poison.Encoder.List."-encode/3-lists^foldr/2-1-"/3
    (poison) lib/poison/encoder.ex:233: Poison.Encoder.List.encode/3
    (poison) lib/poison/encoder.ex:213: anonymous fn/4 in Poison.Encoder.Map.encode/3
    (poison) lib/poison/encoder.ex:214: Poison.Encoder.Map."-encode/3-lists^foldl/2-0-"/3
    (poison) lib/poison/encoder.ex:214: Poison.Encoder.Map.encode/3
    (poison) lib/poison.ex:41: Poison.encode!/2
```

It worked fine when I passed a ```Map```:

```
iex(34)> Hound.Helpers.Cookie.set_cookie(%{"name" => "hi", "value" => "yo"})
nil
iex(35)> Hound.Helpers.Cookie.cookies()                                     
[%{"class" => "org.openqa.selenium.Cookie",
   "domain" => "[hidden]", "hCode" => 3329, "httpOnly" => false,
   "name" => "hi", "path" => "/", "secure" => false, "value" => "yo"}]
```

Proposing correction to the docs.