### PR TITLE
Added ability to fetch the console log

### DIFF
--- a/lib/hound/helpers.ex
+++ b/lib/hound/helpers.ex
@@ -14,6 +14,7 @@ defmodule Hound.Helpers do
       import Hound.Helpers.ScriptExecution
       import Hound.Helpers.Session
       import Hound.Helpers.Window
+      import Hound.Helpers.Log
       import Hound.Matchers
       import unquote(__MODULE__)
     end

--- a/lib/hound/helpers/log.ex
+++ b/lib/hound/helpers/log.ex
@@ -1,0 +1,46 @@
+defmodule Hound.Helpers.Log do
+  @moduledoc "Functions to work with the log"
+
+  import Hound.RequestUtils
+  require Hound.NotSupportedError
+
+  @doc """
+  Fetches console.log() from the browser as a single string of log-lines.
+  """
+  def fetch_log() do
+    fail_if_webdriver_selenium("fetch_log()")
+    
+    get_browser_log()
+    |> Enum.map(&(Map.get(&1, "message")))
+    |> Enum.join("\n")
+  end
+
+  @doc """
+  Fetches all console.log() lines of type 'WARINING' and CRITICAL, from the browser as a single string of log-lines.
+  """
+  def fetch_errors() do
+    fail_if_webdriver_selenium("fetch_errors()")
+    
+    get_browser_log()
+    |> Enum.filter(&(is_error(&1)))
+    |> Enum.map(&(Map.get(&1, "message")))
+    |> Enum.join("\n")
+  end
+
+  defp fail_if_webdriver_selenium(function) do
+    Hound.NotSupportedError.raise_for(%{driver: "selenium", browser: "firefox"}, function)
+  end
+
+  defp get_browser_log() do
+    session_id = Hound.current_session_id
+    make_req(:post, "session/#{session_id}/log", %{type: "browser"})
+  end
+
+  defp is_error(map) do
+    level(map, "WARNING") || level(map, "CRITICAL")
+  end
+  
+  defp level(map, value) do
+    Map.get(map, "level") == value
+  end
+end

--- a/test/helpers/log_test.exs
+++ b/test/helpers/log_test.exs
@@ -1,0 +1,43 @@
+defmodule LogTest do
+  use ExUnit.Case
+  use Hound.Helpers
+
+  hound_session
+
+  test "Should be able to extract log written in javascript" do
+    navigate_to "http://localhost:9090/page1.html"
+    
+    execute_script("console.log(\"Some log\");")
+    execute_script("console.log(\"Next log\");")
+
+    if is_webdriver_selenium() do
+      assert_raise Hound.NotSupportedError, "fetch_log() is not supported by driver selenium with browser firefox", fn ->
+        fetch_log()
+      end
+    else
+      log = fetch_log()
+
+      assert log =~ "Some log"
+      assert log =~ "Next log"
+    end
+  end
+
+  test "Should be able to detect if theres any errors in the javascript" do
+    navigate_to "http://localhost:9090/page_with_javascript_error.html"
+    execute_script("console.log(\"Should not return normal logs\");")
+
+    if is_webdriver_selenium() do
+      assert_raise Hound.NotSupportedError, "fetch_errors() is not supported by driver selenium with browser firefox", fn ->
+        fetch_errors()
+      end
+    else
+      log = fetch_errors()
+      refute log =~ "Should not return normal logs"
+      assert log =~ "This is a javascript error"
+    end
+  end
+
+  defp is_webdriver_selenium() do
+    match?({:ok, %{driver: "selenium"}}, Hound.driver_info)
+  end
+end

--- a/test/sample_pages/page_with_javascript_error.html
+++ b/test/sample_pages/page_with_javascript_error.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Hound Test Page</title>
+  </head>
+  <body>
+    <script type="text/javascript">
+     throw "This is a javascript error";
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Using Hound for some javascript accept tests, it found myself needing to assert on the log output.

I have created a small addition, which can fetch the log and fetch errors written to the log.