### PR TITLE
Corrected mix test runner command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Application.ensure_all_started(:hound)
 ExUnit.start()
 ```
 
-When you run `mix tests`, Hound is automatically started. __You'll need a webdriver server__ running, like Selenium Server or Chrome Driver. If you aren't sure what it is, then [read this](https://github.com/HashNuke/hound/wiki/Starting-a-webdriver-server).
+When you run `mix test`, Hound is automatically started. __You'll need a webdriver server__ running, like Selenium Server or Chrome Driver. If you aren't sure what it is, then [read this](https://github.com/HashNuke/hound/wiki/Starting-a-webdriver-server).
 
 ## Configure
 


### PR DESCRIPTION
Hey :wave: 

Was just setting up hound and realised that the mix command for running the test suite in the readme reads `mix tests` I believe it's supposed to be `mix test`.

Thanks,
.FxN