### PR TITLE
Improve not found element error handling.

### DIFF
--- a/lib/hound/helpers/no_such_element_error.ex
+++ b/lib/hound/helpers/no_such_element_error.ex
@@ -1,0 +1,8 @@
+defmodule Hound.NoSuchElementError do
+  defexception [:strategy, :selector, :parent]
+
+  def message(err) do
+    parent_text = if err.parent, do: "in #{err.parent} ", else: ""
+    "No element #{parent_text}found for #{err.strategy} '#{err.selector}'"
+  end
+end

--- a/lib/hound/request_utils.ex
+++ b/lib/hound/request_utils.ex
@@ -56,6 +56,10 @@ defmodule Hound.RequestUtils do
         Webdriver call status code #{resp.status_code} for #{type} request #{url}.
         Check if webdriver server is running. Make sure it supports the feature being requested.
         """
+      {:error, err} = value ->
+        if options[:safe],
+          do: value,
+          else: raise err
       response -> response
     end
   end

--- a/lib/hound/response_parsers/chrome_driver.ex
+++ b/lib/hound/response_parsers/chrome_driver.ex
@@ -14,7 +14,7 @@ defmodule Hound.ResponseParsers.ChromeDriver do
         warn value["message"]
         value
       is_error?(value) ->
-        raise value["message"]
+        handle_error(value)
       resp["status"] == 0 ->
         value
       status < 400 ->
@@ -23,4 +23,8 @@ defmodule Hound.ResponseParsers.ChromeDriver do
     end
   end
 
+  defp handle_error(%{"message" => "no such element" <> _rest}),
+    do: {:error, :no_such_element}
+  defp handle_error(%{"message" => msg}),
+    do: {:error, msg}
 end

--- a/lib/hound/response_parsers/phantom_js.ex
+++ b/lib/hound/response_parsers/phantom_js.ex
@@ -14,14 +14,21 @@ defmodule Hound.ResponseParsers.PhantomJs do
       is_map(resp["value"]) && Map.has_key?(value, "message") ->
         case Poison.decode(value["message"]) do
           {:ok, decoded_error} ->
-            raise decoded_error["errorMessage"]
+            decoded_error
           _ ->
-            raise value
+            value
         end
+        |> handle_error
 
       status < 400 -> :ok
       true         -> :error
     end
   end
 
+  defp handle_error(%{"errorMessage" => "Unable to find element" <> _rest}),
+    do: {:error, :no_such_element}
+  defp handle_error(%{"errorMessage" => msg}),
+    do: {:error, msg}
+  defp handle_error(err),
+    do: {:error, err}
 end

--- a/lib/hound/response_parsers/selenium.ex
+++ b/lib/hound/response_parsers/selenium.ex
@@ -14,7 +14,7 @@ defmodule Hound.ResponseParsers.Selenium do
         warn value["message"]
         value
       is_error?(value) ->
-        raise value["message"]
+        handle_error(value)
       resp["status"] == 0 ->
         resp["value"]
       status < 400 ->
@@ -23,4 +23,10 @@ defmodule Hound.ResponseParsers.Selenium do
     end
   end
 
+  defp handle_error(%{"class" => "org.openqa.selenium.NoSuchElementException"}) do
+    {:error, :no_such_element}
+  end
+  defp handle_error(err) do
+    {:error, err["message"]}
+  end
 end

--- a/test/helpers/page_test.exs
+++ b/test/helpers/page_test.exs
@@ -34,6 +34,18 @@ defmodule PageTest do
   end
 
 
+  test "find_element/3 should return nil if element does not exist" do
+    navigate_to("http://localhost:9090/page1.html")
+    refute find_element(:css, ".i-dont-exist")
+  end
+
+  test "find_element!/3 should raise NoSuchElementError if element does not exist" do
+    navigate_to("http://localhost:9090/page1.html")
+    assert_raise Hound.NoSuchElementError, fn ->
+      find_element!(:css, ".i-dont-exist")
+    end
+  end
+
   test "should find all elements within page" do
     navigate_to("http://localhost:9090/page1.html")
     element_ids = find_all_elements(:tag, "p")
@@ -51,6 +63,17 @@ defmodule PageTest do
     assert is_binary(element)
   end
 
+  test "find_within_element/4 should return nil if element is not found" do
+    navigate_to("http://localhost:9090/page1.html")
+    container_id = find_element(:class, "container")
+    refute find_within_element(container_id, :class, "i-dont-exist")
+  end
+
+  test "find_within_element!/4 should raise NoSuchElementError if element is not found" do
+    navigate_to("http://localhost:9090/page1.html")
+    container_id = find_element(:class, "container")
+    assert_raise Hound.NoSuchElementError, fn -> find_within_element!(container_id, :class, "i-dont-exist") end
+  end
 
   test "should find all elements within another element" do
     navigate_to("http://localhost:9090/page1.html")


### PR DESCRIPTION
As discussed in #79, I improved error handling.

Here are the main changes.

* Change `find_element/3` and `find_within_element/4` to return nil when
  the element is not found.
* Add `Hound.NoSuchElementError`
* Add `find_element!/4` and `find_within_element!/4`

Let me know what you think.