### PR TITLE
Fix regressions introduced in #80

### DIFF
--- a/lib/hound/helpers/element.ex
+++ b/lib/hound/helpers/element.ex
@@ -309,7 +309,7 @@ defmodule Hound.Helpers.Element do
   defp get_element_id(element) do
     if is_tuple(element) do
       {strategy, selector} = element
-      Hound.Helpers.Page.find_element(strategy, selector)
+      Hound.Helpers.Page.find_element!(strategy, selector)
     else
       element
     end

--- a/test/helpers/element_with_selectors_test.exs
+++ b/test/helpers/element_with_selectors_test.exs
@@ -9,6 +9,13 @@ defmodule ElementWithSelectorsTest do
     assert visible_text({:class, "example"}) == "Paragraph"
   end
 
+  test "should raise when passed selector does not match any element" do
+    navigate_to "http://localhost:9090/page1.html"
+    assert_raise Hound.NoSuchElementError, fn ->
+      visible_text({:class, "i-dont-exist"})
+    end
+  end
+
 
   test "should input value into field, when selector is passed" do
     navigate_to "http://localhost:9090/page1.html"


### PR DESCRIPTION
Sorry, there are two regressions that were introduced in my last PR #80:

* The one spotted by @vitalis, `get_element_id` should raise if element is not found
* Retry not being honored when the element is not found

This should fix both.