### PR TITLE
Use struct for elements instead of using raw ID.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ defmodule HoundTest do
   test "the truth", meta do
     navigate_to("http://example.com/guestbook.html")
 
-    element_id = find_element(:name, "message")
-    fill_field(element_id, "Happy Birthday ~!")
-    submit_element(element_id)
+    element = find_element(:name, "message")
+    fill_field(element, "Happy Birthday ~!")
+    submit_element(element)
 
     assert page_title() == "Thank you"
   end

--- a/lib/hound/element.ex
+++ b/lib/hound/element.ex
@@ -1,0 +1,34 @@
+defmodule Hound.Element do
+  @moduledoc """
+  A representation of a web element
+  """
+
+  defstruct uuid: nil
+  @type t :: %__MODULE__{uuid: String.t}
+
+  @doc """
+  Returns true if the argument is an Element
+  """
+  def element?(%__MODULE__{}), do: true
+  def element?(_),             do: false
+
+  @doc """
+  Returns an element from a driver element response
+  """
+  def from_response(%{"ELEMENT" => uuid}), do: %__MODULE__{uuid: uuid}
+  def from_response(value) do
+    raise Hound.InvalidElementError, value: value
+  end
+end
+
+defimpl Poison.Encoder, for: Hound.Element do
+  def encode(%{uuid: uuid}, options) do
+    Poison.Encoder.Map.encode(%{"ELEMENT" => uuid}, options)
+  end
+end
+
+defimpl String.Chars, for: Hound.Element do
+  def to_string(elem) do
+    elem.uuid
+  end
+end

--- a/lib/hound/exceptions.ex
+++ b/lib/hound/exceptions.ex
@@ -6,3 +6,11 @@ defmodule Hound.NoSuchElementError do
     "No element #{parent_text}found for #{err.strategy} '#{err.selector}'"
   end
 end
+
+defmodule Hound.InvalidElementError do
+  defexception [:value]
+
+  def message(err) do
+    "Could not transform value #{inspect(err.value)} to element"
+  end
+end

--- a/lib/hound/helpers/element.ex
+++ b/lib/hound/helpers/element.ex
@@ -7,10 +7,10 @@ defmodule Hound.Helpers.Element do
   @type element :: element_selector | String.t
 
   @doc """
-  Gets visible text of element. Requires the element ID.
+  Gets visible text of element. Requires the element.
 
-      element_id = find_element(:css, ".example")
-      visible_text(element_id)
+      element = find_element(:css, ".example")
+      visible_text(element)
 
   You can also directly pass the selector as a tuple.
 
@@ -18,9 +18,9 @@ defmodule Hound.Helpers.Element do
   """
   @spec visible_text(element) :: String.t
   def visible_text(element) do
-    element_id = get_element_id(element)
+    element = get_element(element)
     session_id = Hound.current_session_id
-    make_req(:get, "session/#{session_id}/element/#{element_id}/text")
+    make_req(:get, "session/#{session_id}/element/#{element}/text")
   end
 
 
@@ -40,8 +40,8 @@ defmodule Hound.Helpers.Element do
 
   It does not clear the field before entering the new value. Anything passed is added to the value already present.
 
-      element_id = find_element(:id, "example")
-      input_into_field(element_id, "John Doe")
+      element = find_element(:id, "example")
+      input_into_field(element, "John Doe")
 
   You can also pass the selector as a tuple, for the first argument.
 
@@ -49,17 +49,17 @@ defmodule Hound.Helpers.Element do
   """
   @spec input_into_field(element, String.t) :: :ok
   def input_into_field(element, input) do
-    element_id = get_element_id(element)
+    element = get_element(element)
     session_id = Hound.current_session_id
-    make_req(:post, "session/#{session_id}/element/#{element_id}/value", %{value: ["#{input}"]})
+    make_req(:post, "session/#{session_id}/element/#{element}/value", %{value: ["#{input}"]})
   end
 
 
   @doc """
   Sets a field's value. The difference with `input_into_field` is that, the field is cleared before entering the new value.
 
-      element_id = find_element(:id, "example")
-      fill_field(element_id, "John Doe")
+      element = find_element(:id, "example")
+      fill_field(element, "John Doe")
 
   You can also pass the selector as a tuple, for the first argument.
 
@@ -67,18 +67,18 @@ defmodule Hound.Helpers.Element do
   """
   @spec fill_field(element, String.t) :: :ok
   def fill_field(element, input) do
-    element_id = get_element_id(element)
+    element = get_element(element)
     session_id = Hound.current_session_id
-    clear_field(element_id)
-    make_req(:post, "session/#{session_id}/element/#{element_id}/value", %{value: ["#{input}"]})
+    clear_field(element)
+    make_req(:post, "session/#{session_id}/element/#{element}/value", %{value: ["#{input}"]})
   end
 
 
   @doc """
   Gets an element's tag name.
 
-      element_id = find_element(:class, "example")
-      tag_name(element_id)
+      element = find_element(:class, "example")
+      tag_name(element)
 
   You can also directly pass the selector as a tuple.
 
@@ -86,17 +86,17 @@ defmodule Hound.Helpers.Element do
   """
   @spec tag_name(element) :: String.t
   def tag_name(element) do
-    element_id = get_element_id(element)
+    element = get_element(element)
     session_id = Hound.current_session_id
-    make_req(:get, "session/#{session_id}/element/#{element_id}/name")
+    make_req(:get, "session/#{session_id}/element/#{element}/name")
   end
 
 
   @doc """
   Clears textarea or input field's value
 
-      element_id = find_element(:class, "example")
-      clear_field(element_id)
+      element = find_element(:class, "example")
+      clear_field(element)
 
   You can also directly pass the selector as a tuple.
 
@@ -104,17 +104,17 @@ defmodule Hound.Helpers.Element do
   """
   @spec clear_field(element) :: :ok
   def clear_field(element) do
-    element_id = get_element_id(element)
+    element = get_element(element)
     session_id = Hound.current_session_id
-    make_req(:post, "session/#{session_id}/element/#{element_id}/clear")
+    make_req(:post, "session/#{session_id}/element/#{element}/clear")
   end
 
 
   @doc """
   Checks if a radio input group or checkbox has any value selected.
 
-      element_id = find_element(:name, "example")
-      selected?(element_id)
+      element = find_element(:name, "example")
+      selected?(element)
 
   You can also pass the selector as a tuple.
 
@@ -122,17 +122,17 @@ defmodule Hound.Helpers.Element do
   """
   @spec selected?(element) :: :true | :false
   def selected?(element) do
-    element_id = get_element_id(element)
+    element = get_element(element)
     session_id = Hound.current_session_id
-    make_req(:get, "session/#{session_id}/element/#{element_id}/selected")
+    make_req(:get, "session/#{session_id}/element/#{element}/selected")
   end
 
 
   @doc """
   Checks if an input field is enabled.
 
-      element_id = find_element(:name, "example")
-      element_enabled?(element_id)
+      element = find_element(:name, "example")
+      element_enabled?(element)
 
   You can also pass the selector as a tuple.
 
@@ -140,17 +140,17 @@ defmodule Hound.Helpers.Element do
   """
   @spec element_enabled?(element) :: :true | :false
   def element_enabled?(element) do
-    element_id = get_element_id(element)
+    element = get_element(element)
     session_id = Hound.current_session_id
-    make_req(:get, "session/#{session_id}/element/#{element_id}/enabled")
+    make_req(:get, "session/#{session_id}/element/#{element}/enabled")
   end
 
 
   @doc """
   Gets an element's attribute value.
 
-      element_id = find_element(:name, "example")
-      attribute_value(element_id, "data-greeting")
+      element = find_element(:name, "example")
+      attribute_value(element, "data-greeting")
 
   You can also pass the selector as a tuple, for the first argument
 
@@ -158,17 +158,17 @@ defmodule Hound.Helpers.Element do
   """
   @spec attribute_value(element, String.t) :: String.t | :nil
   def attribute_value(element, attribute_name) do
-    element_id = get_element_id(element)
+    element = get_element(element)
     session_id = Hound.current_session_id
-    make_req(:get, "session/#{session_id}/element/#{element_id}/attribute/#{attribute_name}")
+    make_req(:get, "session/#{session_id}/element/#{element}/attribute/#{attribute_name}")
   end
 
 
   @doc """
   Checks if an element has a given class.
 
-      element_id = find_element(:class, "another_example")
-      has_class?(element_id, "another_class")
+      element = find_element(:class, "another_example")
+      has_class?(element, "another_class")
 
   You can also pass the selector as a tuple, for the first argument
 
@@ -182,24 +182,24 @@ defmodule Hound.Helpers.Element do
 
 
   @doc """
-  Checks if two element IDs refer to the same DOM element.
+  Checks if two elements refer to the same DOM element.
 
-      element_id1 = find_element(:name, "username")
-      element_id2 = find_element(:id, "user_name")
-      same_element?(element_id1, element_id2)
+      element1 = find_element(:name, "username")
+      element2 = find_element(:id, "user_name")
+      same_element?(element1, element2)
   """
   @spec same_element?(String.t, String.t) :: :true | :false
-  def same_element?(element_id1, element_id2) do
+  def same_element?(element1, element2) do
     session_id = Hound.current_session_id
-    make_req(:get, "session/#{session_id}/element/#{element_id1}/equals/#{element_id2}")
+    make_req(:get, "session/#{session_id}/element/#{element1}/equals/#{element2}")
   end
 
 
   @doc """
   Checks if an element is currently displayed.
 
-      element_id = find_element(:name, "example")
-      element_displayed?(element_id)
+      element = find_element(:name, "example")
+      element_displayed?(element)
 
   You can also pass the selector as a tuple.
 
@@ -207,17 +207,17 @@ defmodule Hound.Helpers.Element do
   """
   @spec element_displayed?(element) :: :true | :false
   def element_displayed?(element) do
-    element_id = get_element_id(element)
+    element = get_element(element)
     session_id = Hound.current_session_id
-    make_req(:get, "session/#{session_id}/element/#{element_id}/displayed")
+    make_req(:get, "session/#{session_id}/element/#{element}/displayed")
   end
 
 
   @doc """
   Gets an element's location on page. It returns the location as a tuple of the form {x, y}.
 
-      element_id = find_element(:name, "example")
-      element_location(element_id)
+      element = find_element(:name, "example")
+      element_location(element)
 
   You can also pass the selector as a tuple.
 
@@ -225,9 +225,9 @@ defmodule Hound.Helpers.Element do
   """
   @spec element_location(element) :: tuple
   def element_location(element) do
-    element_id = get_element_id(element)
+    element = get_element(element)
     session_id = Hound.current_session_id
-    result = make_req(:get, "session/#{session_id}/element/#{element_id}/location")
+    result = make_req(:get, "session/#{session_id}/element/#{element}/location")
     {result["x"], result["y"]}
   end
 
@@ -235,8 +235,8 @@ defmodule Hound.Helpers.Element do
   @doc """
   Gets an element's size in pixels. It returns the size as a tuple of the form {width, height}.
 
-      element_id = find_element(:name, "example")
-      element_location(element_id)
+      element = find_element(:name, "example")
+      element_location(element)
 
   You can also pass the selector as a tuple.
 
@@ -244,9 +244,9 @@ defmodule Hound.Helpers.Element do
   """
   @spec element_size(element) :: tuple
   def element_size(element) do
-    element_id = get_element_id(element)
+    element = get_element(element)
     session_id = Hound.current_session_id
-    result = make_req(:get, "session/#{session_id}/element/#{element_id}/size")
+    result = make_req(:get, "session/#{session_id}/element/#{element}/size")
     {result["width"], result["height"]}
   end
 
@@ -254,8 +254,8 @@ defmodule Hound.Helpers.Element do
   @doc """
   Gets an element's computed CSS property.
 
-      element_id = find_element(:name, "example")
-      css_property(element_id, "display")
+      element = find_element(:name, "example")
+      css_property(element, "display")
 
   You can also pass the selector as a tuple, for the first argument
 
@@ -263,17 +263,17 @@ defmodule Hound.Helpers.Element do
   """
   @spec css_property(element, String.t) :: String.t
   def css_property(element, property_name) do
-    element_id = get_element_id(element)
+    element = get_element(element)
     session_id = Hound.current_session_id
-    make_req(:get, "session/#{session_id}/element/#{element_id}/css/#{property_name}")
+    make_req(:get, "session/#{session_id}/element/#{element}/css/#{property_name}")
   end
 
 
   @doc """
   Click on an element. You can also use this to click on checkboxes and radio buttons.
 
-      element_id = find_element(:id, ".example")
-      click(element_id)
+      element = find_element(:id, ".example")
+      click(element)
 
   You can also directly pass the selector as a tuple.
 
@@ -281,17 +281,17 @@ defmodule Hound.Helpers.Element do
   """
   @spec click(element) :: :ok
   def click(element) do
-    element_id = get_element_id(element)
+    element = get_element(element)
     session_id = Hound.current_session_id
-    make_req(:post, "session/#{session_id}/element/#{element_id}/click")
+    make_req(:post, "session/#{session_id}/element/#{element}/click")
   end
 
 
   @doc """
   Sends a submit event to any field or form element.
 
-      element_id = find_element(:name, "username")
-      submit(element_id)
+      element = find_element(:name, "username")
+      submit(element)
 
   You can also directly pass the selector as a tuple.
 
@@ -299,19 +299,15 @@ defmodule Hound.Helpers.Element do
   """
   @spec submit_element(element) :: :ok
   def submit_element(element) do
-    element_id = get_element_id(element)
+    element = get_element(element)
     session_id = Hound.current_session_id
-    make_req(:post, "session/#{session_id}/element/#{element_id}/submit")
+    make_req(:post, "session/#{session_id}/element/#{element}/submit")
   end
 
 
   @doc false
-  defp get_element_id(element) do
-    if is_tuple(element) do
-      {strategy, selector} = element
-      Hound.Helpers.Page.find_element!(strategy, selector)
-    else
-      element
-    end
-  end
+  defp get_element({strategy, selector}),
+    do: Hound.Helpers.Page.find_element!(strategy, selector)
+  defp get_element(%Hound.Element{} = elem),
+    do: elem
 end

--- a/test/element_test.exs
+++ b/test/element_test.exs
@@ -1,0 +1,27 @@
+defmodule ElementTest do
+  use ExUnit.Case
+
+  alias Hound.Element
+
+  test "encoding to JSON" do
+    uuid = "some-uuid"
+    element = %Element{uuid: uuid}
+    assert Poison.encode!(element) == ~s({"ELEMENT":"#{uuid}"})
+  end
+
+  test "string representation" do
+    uuid = "some-uuid"
+    element = %Element{uuid: uuid}
+    assert to_string(element) == uuid
+  end
+
+  test "element?/1" do
+    assert Element.element?(%Element{uuid: "foo"})
+    refute Element.element?("foo")
+  end
+
+  test "from_response/1" do
+    assert Element.from_response(%{"ELEMENT" => "uuid"}) == %Element{uuid: "uuid"}
+    assert_raise Hound.InvalidElementError, fn -> Element.from_response(%{"value" => "foo"}) end
+  end
+end

--- a/test/helpers/element_with_ids_test.exs
+++ b/test/helpers/element_with_ids_test.exs
@@ -6,107 +6,107 @@ defmodule ElementTestWithIds do
 
   test "should get visible text of an element" do
     navigate_to "http://localhost:9090/page1.html"
-    element_id = find_element(:class, "example")
-    assert visible_text(element_id) == "Paragraph"
+    element = find_element(:class, "example")
+    assert visible_text(element) == "Paragraph"
   end
 
 
   test "should input value into field" do
     navigate_to "http://localhost:9090/page1.html"
-    element_id = find_element(:name, "username")
+    element = find_element(:name, "username")
 
-    input_into_field(element_id, "john")
-    assert attribute_value(element_id, "value") == "john"
+    input_into_field(element, "john")
+    assert attribute_value(element, "value") == "john"
 
-    input_into_field(element_id, "doe")
-    assert attribute_value(element_id, "value") == "johndoe"
+    input_into_field(element, "doe")
+    assert attribute_value(element, "value") == "johndoe"
   end
 
 
   test "should fill a field with a value" do
     navigate_to "http://localhost:9090/page1.html"
-    element_id = find_element(:name, "username")
+    element = find_element(:name, "username")
 
-    fill_field(element_id, "johndoe")
-    assert attribute_value(element_id, "value") == "johndoe"
+    fill_field(element, "johndoe")
+    assert attribute_value(element, "value") == "johndoe"
 
-    fill_field(element_id, "janedoe")
-    assert attribute_value(element_id, "value") == "janedoe"
+    fill_field(element, "janedoe")
+    assert attribute_value(element, "value") == "janedoe"
   end
 
 
   test "should get tag name of element" do
     navigate_to "http://localhost:9090/page1.html"
-    element_id = find_element(:name, "username")
-    assert tag_name(element_id) == "input"
+    element = find_element(:name, "username")
+    assert tag_name(element) == "input"
   end
 
 
   test "should clear field" do
     navigate_to "http://localhost:9090/page1.html"
-    element_id = find_element(:name, "username")
-    fill_field(element_id, "johndoe")
-    assert attribute_value(element_id, "value") == "johndoe"
+    element = find_element(:name, "username")
+    fill_field(element, "johndoe")
+    assert attribute_value(element, "value") == "johndoe"
 
-    clear_field(element_id)
-    assert attribute_value(element_id, "value") == ""
+    clear_field(element)
+    assert attribute_value(element, "value") == ""
   end
 
 
   test "should return true if item is selected in a checkbox or radio" do
     navigate_to "http://localhost:9090/page1.html"
-    element_id = find_element :id, "speed-superpower"
-    click element_id
-    assert selected?(element_id)
+    element = find_element :id, "speed-superpower"
+    click element
+    assert selected?(element)
   end
 
 
   test "should return false if item is *not* selected" do
     navigate_to "http://localhost:9090/page1.html"
-    element_id = find_element :id, "speed-flying"
-    assert selected?(element_id) == false
+    element = find_element :id, "speed-flying"
+    assert selected?(element) == false
   end
 
 
   test "Should return true if element is enabled" do
     navigate_to "http://localhost:9090/page1.html"
-    element_id = find_element(:name, "username")
-    assert element_enabled?(element_id) == true
+    element = find_element(:name, "username")
+    assert element_enabled?(element) == true
   end
 
 
   test "Should return false if element is *not* enabled" do
     navigate_to "http://localhost:9090/page1.html"
-    element_id = find_element(:name, "promocode")
-    assert element_enabled?(element_id) == false
+    element = find_element(:name, "promocode")
+    assert element_enabled?(element) == false
   end
 
 
   test "should get attribute value of an element" do
     navigate_to "http://localhost:9090/page1.html"
-    element_id = find_element(:class, "example")
-    assert attribute_value(element_id, "data-greeting") == "hello"
+    element = find_element(:class, "example")
+    assert attribute_value(element, "data-greeting") == "hello"
   end
 
 
   test "should return true if an element is displayed" do
     navigate_to "http://localhost:9090/page1.html"
-    element_id = find_element(:class, "example")
-    assert element_displayed?(element_id)
+    element = find_element(:class, "example")
+    assert element_displayed?(element)
   end
 
 
   test "should return false if an element is *not* displayed" do
     navigate_to "http://localhost:9090/page1.html"
-    element_id = find_element(:class, "hidden-element")
-    assert element_displayed?(element_id) == false
+    element = find_element(:class, "hidden-element")
+    assert element_displayed?(element) == false
   end
 
 
   test "should get an element's location on screen" do
     navigate_to "http://localhost:9090/page1.html"
-    element_id = find_element :class, "example"
-    {loc_x, loc_y} = element_location(element_id)
+    element = find_element :class, "example"
+    {loc_x, loc_y} = element_location(element)
     assert is_integer(loc_x) || is_float(loc_x)
     assert is_integer(loc_y) || is_float(loc_y)
   end
@@ -114,31 +114,31 @@ defmodule ElementTestWithIds do
 
   test "should get an element's size" do
     navigate_to "http://localhost:9090/page1.html"
-    element_id = find_element(:class, "example")
-    size = element_size(element_id)
+    element = find_element(:class, "example")
+    size = element_size(element)
     assert size == {400, 100}
   end
 
 
   test "should get css property of an element" do
     navigate_to "http://localhost:9090/page1.html"
-    element_id = find_element(:class, "container")
-    assert css_property(element_id, "display") == "block"
+    element = find_element(:class, "container")
+    assert css_property(element, "display") == "block"
   end
 
 
   test "should click on an element" do
     navigate_to "http://localhost:9090/page1.html"
-    element_id = find_element(:class, "submit-form")
-    click element_id
+    element = find_element(:class, "submit-form")
+    click element
     assert current_url == "http://localhost:9090/page2.html"
   end
 
 
   test "should submit a form element" do
     navigate_to "http://localhost:9090/page1.html"
-    element_id = find_element(:name, "username")
-    submit_element(element_id)
+    element = find_element(:name, "username")
+    submit_element(element)
     assert current_url == "http://localhost:9090/page2.html"
   end
 end

--- a/test/helpers/page_test.exs
+++ b/test/helpers/page_test.exs
@@ -2,6 +2,8 @@ defmodule PageTest do
   use ExUnit.Case
   use Hound.Helpers
 
+  alias Hound.Element
+
   hound_session
 
   test "should get page source" do
@@ -30,7 +32,7 @@ defmodule PageTest do
 
   test "should find element within page" do
     navigate_to("http://localhost:9090/page1.html")
-    assert is_binary(find_element(:css, ".example"))
+    assert Element.element?(find_element(:css, ".example"))
   end
 
 
@@ -48,10 +50,10 @@ defmodule PageTest do
 
   test "should find all elements within page" do
     navigate_to("http://localhost:9090/page1.html")
-    element_ids = find_all_elements(:tag, "p")
-    assert length(element_ids) == 6
-    for element_id <- element_ids do
-      assert is_binary(element_id)
+    elements = find_all_elements(:tag, "p")
+    assert length(elements) == 6
+    for element <- elements do
+      assert Element.element?(element)
     end
   end
 
@@ -60,7 +62,7 @@ defmodule PageTest do
     navigate_to("http://localhost:9090/page1.html")
     container_id = find_element(:class, "container")
     element = find_within_element(container_id, :class, "example")
-    assert is_binary(element)
+    assert Element.element?(element)
   end
 
   test "find_within_element/4 should return nil if element is not found" do
@@ -78,17 +80,17 @@ defmodule PageTest do
   test "should find all elements within another element" do
     navigate_to("http://localhost:9090/page1.html")
     container_id = find_element(:class, "container")
-    element_ids = find_all_within_element(container_id, :tag, "p")
-    assert length(element_ids) == 2
-    for element_id <- element_ids do
-      assert is_binary(element_id)
+    elements = find_all_within_element(container_id, :tag, "p")
+    assert length(elements) == 2
+    for element <- elements do
+      assert Element.element?(element)
     end
   end
 
 
   test "should get element in focus" do
     navigate_to("http://localhost:9090/page1.html")
-    assert is_binary(element_in_focus())
+    assert Element.element?(element_in_focus())
   end
 
 

--- a/test/helpers/script_execution_test.exs
+++ b/test/helpers/script_execution_test.exs
@@ -14,4 +14,11 @@ defmodule ScriptExecutionTest do
     navigate_to "http://localhost:9090/page1.html"
     assert execute_script_async("arguments[arguments.length-1]('hello')", []) == "hello"
   end
+
+
+  test "Pass element to javascript" do
+    navigate_to "http://localhost:9090/page1.html"
+    element = find_element(:id, "speed-flying")
+    assert execute_script("return(arguments[0].value);", [element]) == "flying"
+  end
 end


### PR DESCRIPTION
Until now, it was impossible to distinguish a normal string from an element, which
was causing trouble when passing an element while executing JS.
As discussed in #84, I wrapped in elements in their own struct to have more flexibility,
especially on how they should be serialized.

The serialization part is protocol based, so I only needed to implement `Poison.Encoder`
for post requests and `String.Chars` for get requests to get it to work.
The deserialization part is handed by `Hound.Element.from_response/1`.

I also [added and fixed typespecs](https://github.com/tuvistavie/hound/tree/fix-typespecs), but I left it as another PR as there is already enough noise in this one. Let me know if you prefer me to merge it here first.