### PR TITLE
Improve HTTPoison error handling.

### DIFF
--- a/lib/hound/helpers/navigation.ex
+++ b/lib/hound/helpers/navigation.ex
@@ -21,11 +21,11 @@ defmodule Hound.Helpers.Navigation do
       navigate_to("http://example.com/page1")
       navigate_to("/page1")
   """
-  @spec navigate_to(String.t) :: :ok
-  def navigate_to(url) do
+  @spec navigate_to(String.t, integer) :: nil
+  def navigate_to(url, retries \\ 0) do
     final_url = generate_final_url(url)
     session_id = Hound.current_session_id
-    make_req(:post, "session/#{session_id}/url", %{url: final_url})
+    make_req(:post, "session/#{session_id}/url", %{url: final_url}, %{}, retries)
   end
 
 


### PR DESCRIPTION
This should avoid raising an exception on timeout and connection refused errors and fixes #75.

@HashNuke There are two points I would like to discuss a little

1. Adding the retry parameter to `navigate_to`

   I think the use case is common enough, what do you think?

2. Handling connection refused errors

   With the old implementation, we got a `MatchError`, and with the current one, we get `{:error, :econnrefused}`. As it is almost for sure a sign that the driver is not running, raising an exception with a clear error message, eventually linking to the documentation would be I think nicer for this particular case. What do you think?