### PR TITLE
Add NotSupportedError.

### DIFF
--- a/lib/hound/exceptions.ex
+++ b/lib/hound/exceptions.ex
@@ -14,3 +14,14 @@ defmodule Hound.InvalidElementError do
     "Could not transform value #{inspect(err.value)} to element"
   end
 end
+
+defmodule Hound.NotSupportedError do
+  defexception [:function, :browser, :driver]
+
+  def message(err) do
+    {:ok, info} = Hound.ConnectionServer.driver_info
+    driver = err.driver || info.driver
+    browser = err.browser || info.browser
+    "#{err.function} is not supported by driver #{driver} with browser #{browser}"
+  end
+end

--- a/test/exceptions_test.exs
+++ b/test/exceptions_test.exs
@@ -1,0 +1,17 @@
+defmodule HoundNotSupportedErrorTest do
+  use ExUnit.Case
+
+  test "message" do
+    {:ok, info} = Hound.ConnectionServer.driver_info
+    function_name = "foo"
+    err = try do
+            raise Hound.NotSupportedError, function: function_name
+          rescue
+            e -> Exception.message(e)
+          end
+    assert err =~ "not supported"
+    assert err =~ function_name
+    assert err =~ info.driver
+    assert err =~ info.browser
+  end
+end


### PR DESCRIPTION
This should be raised when a feature is used and the driver/browser does not support it.