### PR TITLE
Add minimal implementation of firefox profile.

### DIFF
--- a/lib/hound/firefox/profile.ex
+++ b/lib/hound/firefox/profile.ex
@@ -1,0 +1,40 @@
+defmodule Hound.Firefox.Profile do
+  @default_prefs %{
+  }
+
+  defstruct [prefs: @default_prefs]
+
+  def new do
+    %__MODULE__{}
+  end
+
+  def get_preference(%__MODULE__{prefs: prefs}, key) do
+    Map.get(prefs, key)
+  end
+
+  def put_preference(profile, key, value) do
+    %{profile | prefs: Map.put(profile.prefs, key, value)}
+  end
+
+  def set_user_agent(profile, user_agent) do
+    put_preference(profile, "general.useragent.override", user_agent)
+  end
+
+  def serialize_preferences(profile) do
+    profile.prefs
+    |> Enum.map(fn {key, value} ->
+      ~s[user_pref("#{key}", #{Poison.encode!(value)});]
+    end)
+    |> Enum.join("\n")
+  end
+
+  def dump(profile) do
+    files = [{'user.js', serialize_preferences(profile)}]
+    case :zip.create('profile.zip', files, [:memory]) do
+      {:ok, {_filename, binary}} ->
+        {:ok, Base.encode64(binary)}
+      {:error, _reason} = error ->
+        error
+    end
+  end
+end

--- a/test/firefox/profile_test.exs
+++ b/test/firefox/profile_test.exs
@@ -1,0 +1,44 @@
+defmodule Firefox.ProfileTest do
+  use ExUnit.Case
+
+  alias Hound.Firefox.Profile
+
+  test "new/1 returns a new Profile" do
+    assert %Profile{} = Profile.new
+  end
+
+  test "get_preference/2 returns the preference value or nil" do
+    profile = Profile.new |> Profile.put_preference("foo", "bar")
+    assert Profile.get_preference(profile, "foo") == "bar"
+    refute Profile.get_preference(profile, "bar")
+  end
+
+  test "put_preference/3 set the preference to the profile" do
+    profile = Profile.new
+    refute Profile.get_preference(profile, "foo")
+    profile = Profile.put_preference(profile, "foo", "bar")
+    assert Profile.get_preference(profile, "foo") == "bar"
+  end
+
+  test "serialize_preferences/1 returns profile serialized as JS" do
+    profile =
+      Profile.new
+      |> Profile.put_preference("foo", "bar")
+      |> Profile.put_preference("bar", 3)
+    serialized = Profile.serialize_preferences(profile)
+    assert serialized =~ ~s{user_pref("foo", "bar");}
+    assert serialized =~ ~s{user_pref("bar", 3);}
+  end
+
+  test "dump/1 returns a valid base64 profile" do
+    profile =
+      Profile.new
+      |> Profile.put_preference("foo", "bar")
+      |> Profile.put_preference("bar", 3)
+    assert {:ok, b64_profile} = Profile.dump(profile)
+    {:ok, files} = :zip.extract(Base.decode64!(b64_profile), [:memory])
+    assert [{'user.js', user_prefs}] = files
+    assert user_prefs =~ ~s{user_pref("foo", "bar");}
+    assert user_prefs =~ ~s{user_pref("bar", 3);}
+  end
+end


### PR DESCRIPTION
This is a very minimal implementation of Firefox profile.
It is enough to set the user agent, but we may need to
add at least some utility to load an existing profile.

The usage looks like this:

```elixir
alias Hound.Firefox.Profile

profile = 
  Profile.new
  |> Profile.set_user_agent("my_ua_string")
  |> Profile.put_preference("some.key", "some-value")
  |> Profile.dump
Hound.start_session(%{firefox_profile: profile})
```

I am not sure if there is some preferences we should add to `default_prefs`,
if anyone has any idea, let me know.
Also, I am not sure if it is ok to have everything in `user.js` or if we really need
to make a difference between `prefs.js` and `user.js`, any idea?

/cc @darksheik @HashNuke