### PR TITLE
Add metadata functionality.

### DIFF
--- a/lib/hound.ex
+++ b/lib/hound.ex
@@ -20,17 +20,14 @@ defmodule Hound do
   end
 
 
-  @doc "Alias of Hound.Helpers.Session.start_session"
-  defdelegate start_session,                               to: Hound.Helpers.Session
-  defdelegate start_session(additional_capabilities),      to: Hound.Helpers.Session
+  @doc "See `Hound.Helpers.Session.start_session/1`"
+  defdelegate start_session,            to: Hound.Helpers.Session
+  defdelegate start_session(opts),      to: Hound.Helpers.Session
 
-  @doc "Alias of Hound.Helpers.Session.end_session"
+  @doc "See `Hound.Helpers.Session.end_session/1`"
   defdelegate end_session,        to: Hound.Helpers.Session
-
-  @doc "Alias of Hound.Helpers.Session.end_session/1"
   defdelegate end_session(pid),   to: Hound.Helpers.Session
 
   @doc false
   defdelegate current_session_id, to: Hound.Helpers.Session
-
 end

--- a/lib/hound/browser.ex
+++ b/lib/hound/browser.ex
@@ -1,0 +1,61 @@
+defmodule Hound.Browser do
+  @moduledoc "Low level functions to customize browser behavior"
+
+  @type t :: Hound.BrowserLike.t
+
+  @callback default_user_agent :: String.t | atom
+
+  @callback user_agent_capabilities(String.t) :: map
+
+  @doc "Creates capabilities for the browser and options, to be sent to the webdriver"
+  @spec make_capabilities(t, map | Keyword.t) :: map
+  def make_capabilities(browser_name, opts \\ []) do
+    browser = browser(browser_name)
+
+    user_agent =
+      user_agent(opts[:user_agent] || browser.default_user_agent)
+      |> Hound.Metadata.append(opts[:metadata])
+
+    capabilities = %{browserName: browser_name}
+    ua_capabilities = browser.user_agent_capabilities(user_agent)
+
+    Map.merge(capabilities, ua_capabilities)
+  end
+
+  @doc "Returns a user agent string"
+  @spec user_agent(String.t | atom) :: String.t
+  def user_agent(ua) when is_binary(ua), do: ua
+
+  # bundle a few common user agents
+  def user_agent(:firefox_desktop) do
+    "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1"
+  end
+  def user_agent(:phantomjs) do
+    "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.1.1 Safari/538.1"
+  end
+  def user_agent(:chrome_desktop) do
+    "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
+  end
+  def user_agent(:chrome_android_sp) do
+    "Mozilla/5.0 (Linux; U; Android-4.0.3; en-us; Galaxy Nexus Build/IML74K) AppleWebKit/535.7 (KHTML, like Gecko) CrMo/16.0.912.75 Mobile Safari/535.7"
+  end
+  def user_agent(:chrome_iphone) do
+    "Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; en) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/7534.48.3"
+  end
+  def user_agent(:safari_iphone) do
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25"
+  end
+
+  # add some simpler aliases
+  def user_agent(:chrome),  do: user_agent(:chrome_desktop)
+  def user_agent(:firefox), do: user_agent(:firefox_desktop)
+  def user_agent(:android), do: user_agent(:chrome_android_sp)
+  def user_agent(:iphone),  do: user_agent(:safari_iphone)
+
+  defp browser(browser) when is_atom(browser) do
+    browser |> Atom.to_string |> browser()
+  end
+  defp browser("firefox"),   do: Hound.Browser.Firefox
+  defp browser("chrome"),    do: Hound.Browser.Chrome
+  defp browser("phantomjs"), do: Hound.Browser.PhantomJS
+end

--- a/lib/hound/browsers/chrome.ex
+++ b/lib/hound/browsers/chrome.ex
@@ -1,0 +1,11 @@
+defmodule Hound.Browser.Chrome do
+  @moduledoc false
+
+  @behaviour Hound.Browser
+
+  def default_user_agent, do: :chrome
+
+  def user_agent_capabilities(ua) do
+    %{chromeOptions: %{"args" => ["--user-agent=#{ua}"]}}
+  end
+end

--- a/lib/hound/browsers/firefox.ex
+++ b/lib/hound/browsers/firefox.ex
@@ -1,0 +1,14 @@
+defmodule Hound.Browser.Firefox do
+  @moduledoc false
+
+  @behaviour Hound.Browser
+
+  alias Hound.Browser.Firefox.Profile
+
+  def default_user_agent, do: :firefox
+
+  def user_agent_capabilities(ua) do
+    {:ok, profile} = Profile.new |> Profile.set_user_agent(ua) |> Profile.dump
+    %{firefox_profile: profile}
+  end
+end

--- a/lib/hound/browsers/firefox/profile.ex
+++ b/lib/hound/browsers/firefox/profile.ex
@@ -1,4 +1,6 @@
-defmodule Hound.Firefox.Profile do
+defmodule Hound.Browser.Firefox.Profile do
+  @moduledoc false
+
   @default_prefs %{
   }
 

--- a/lib/hound/browsers/phantomjs.ex
+++ b/lib/hound/browsers/phantomjs.ex
@@ -1,0 +1,11 @@
+defmodule Hound.Browser.PhantomJS do
+  @moduledoc false
+
+  @behaviour Hound.Browser
+
+  def default_user_agent, do: :phantomjs
+
+  def user_agent_capabilities(ua) do
+    %{"phantomjs.page.settings.userAgent" => ua}
+  end
+end

--- a/lib/hound/exceptions.ex
+++ b/lib/hound/exceptions.ex
@@ -51,3 +51,11 @@ defmodule Hound.NotSupportedError do
     end
   end
 end
+
+defmodule Hound.InvalidMetadataError do
+  defexception [:value]
+
+  def message(err) do
+    "could not parse metadata for value #{err.value}"
+  end
+end

--- a/lib/hound/helpers.ex
+++ b/lib/hound/helpers.ex
@@ -21,11 +21,10 @@ defmodule Hound.Helpers do
   end
 
 
-  defmacro hound_session do
+  defmacro hound_session(opts \\ []) do
     quote do
       setup do
-        Hound.start_session
-        on_exit fn-> Hound.end_session end
+        Hound.start_session(unquote(opts))
 
         :ok
       end

--- a/lib/hound/helpers/session.ex
+++ b/lib/hound/helpers/session.ex
@@ -13,8 +13,8 @@ defmodule Hound.Helpers.Session do
 
   The name can be an atom or a string. The default session created is called `:default`.
   """
-  def change_session_to(session_name, additional_capabilities \\ %{}) do
-    Hound.SessionServer.change_current_session_for_pid(self, session_name, additional_capabilities)
+  def change_session_to(session_name, opts \\ []) do
+    Hound.SessionServer.change_current_session_for_pid(self, session_name, opts)
   end
 
 
@@ -74,9 +74,25 @@ defmodule Hound.Helpers.Session do
         end
 
       end
+
+  ## Options
+
+  The following options can be passed to `start_session`:
+
+    * `:browser` - The browser to be used (`"chrome"` | `"phantomjs"` | `"firefox"`)
+    * `:user_agent` - The user agent string that will be used for the requests.
+      The following atoms can also be passed
+        * `:firefox_desktop` (aliased to `:firefox`)
+        * `:chrome_desktop` (aliased to `:chrome`)
+        * `:phantomjs`
+        * `:chrome_android_sp` (aliased to `:android`)
+        * `:safari_iphone` (aliased to `:iphone`)
+    * `:metadata` - The metadata to be included in the requests.
+      See `Hound.Metadata` for more information
+    * `:driver` - The additional capabilities to be passed directly to the webdriver.
   """
-  def start_session(additional_capabilities \\ %{}) do
-    Hound.SessionServer.session_for_pid(self, additional_capabilities)
+  def start_session(opts \\ []) do
+    Hound.SessionServer.session_for_pid(self, opts)
   end
 
 
@@ -95,5 +111,4 @@ defmodule Hound.Helpers.Session do
     Hound.SessionServer.current_session_id(self) ||
       raise "could not find a session for process #{inspect self}"
   end
-
 end

--- a/lib/hound/metadata.ex
+++ b/lib/hound/metadata.ex
@@ -1,0 +1,73 @@
+defmodule Hound.Metadata do
+  @moduledoc """
+  Metadata allows to pass and extract custom data through.
+  This can be useful if you need to identify sessions.
+
+  The keys and values must be serializable using `:erlang.term_to_binary/1`.
+
+  ## Examples
+
+  You can start a session using metadata by doing the following:
+
+      Hound.start_session(metadata: %{pid: self()})
+
+
+  If you need to retrieve the metadata, you simply need to use
+  `Hound.Metadata.extract/1` on the user agent string, so supposing you are using plug,
+
+
+      user_agent =  conn |> get_resp_header("user-agent") |> List.first
+      metadata   = Hound.Metadata.extract(user_agent)
+      assert %{pid: pid} = metadata
+      # you can use your pid here
+
+  """
+
+  @metadata_prefix "BeamMetadata"
+  @extract_regexp ~r{#{@metadata_prefix} \((.*?)\)}
+
+  @doc """
+  Appends the metdata to the user_agent string.
+  """
+  @spec append(String.t, nil | map | String.t) :: String.t
+  def append(user_agent, nil), do: user_agent
+  def append(user_agent, metadata) when is_map(metadata) or is_list(metadata) do
+    append(user_agent, format(metadata))
+  end
+  def append(user_agent, metadata) when is_binary(metadata) do
+    "#{user_agent}/#{metadata}"
+  end
+
+  @doc """
+  Formats a string to a valid UserAgent string to be passed to be
+  appended to the browser user agent.
+  """
+  @spec format(map | Keyword.t) :: String.t
+  def format(metadata) do
+    encoded = {:v1, metadata} |> :erlang.term_to_binary |> Base.url_encode64
+    "#{@metadata_prefix} (#{encoded})"
+  end
+
+  @doc """
+  Extracts and parses the metadata contained in a user agent string.
+  If the user agent does not contain any metadata, an empty map is returned.
+  """
+  @spec parse(String.t) :: %{String.t => String.t}
+  def extract(str) do
+    ua_last_part = str |> String.split("/") |> List.last
+    case Regex.run(@extract_regexp, ua_last_part) do
+      [_, metadata] -> parse(metadata)
+      _             -> %{}
+    end
+  end
+
+  defp parse(encoded_metadata) do
+    encoded_metadata
+    |> Base.url_decode64!
+    |> :erlang.binary_to_term
+    |> case do
+         {:v1, metadata} -> metadata
+         _               -> raise Hound.InvalidMetadataError, value: encoded_metadata
+    end
+  end
+end

--- a/lib/hound/session.ex
+++ b/lib/hound/session.ex
@@ -18,27 +18,33 @@ defmodule Hound.Session do
 
 
   @doc "Creates a session associated with the current pid"
-  @spec create_session(String.t, map) :: {:ok, String.t}
-  def create_session(browser_name, additional_capabilities) do
-    base_capabilities = %{
-      javascriptEnabled: false,
-      version: "",
-      rotatable: false,
-      takesScreenshot: true,
-      cssSelectorsEnabled: true,
-      browserName: browser_name,
-      nativeEvents: false,
-      platform: "ANY"
-    }
-
+  @spec create_session(Hound.Browser.t, map | Keyword.t) :: {:ok, String.t}
+  def create_session(browser, opts) do
+    capabilities = make_capabilities(browser, opts)
     params = %{
-      desiredCapabilities: Map.merge(base_capabilities, additional_capabilities)
+      desiredCapabilities: capabilities
     }
 
     # No retries for this request
     make_req(:post, "session", params)
   end
 
+  @doc "Make capabilities for session"
+  @spec make_capabilities(Hound.Browser.t, map | Keyword.t) :: map
+  def make_capabilities(browser, opts \\ []) do
+    browser = opts[:browser] || browser
+    %{
+      javascriptEnabled: false,
+      version: "",
+      rotatable: false,
+      takesScreenshot: true,
+      cssSelectorsEnabled: true,
+      nativeEvents: false,
+      platform: "ANY"
+    }
+    |> Map.merge(Hound.Browser.make_capabilities(browser, opts))
+    |> Map.merge(opts[:driver] || %{})
+  end
 
   @doc "Get capabilities of a particular session"
   @spec session_info(String.t) :: map
@@ -59,5 +65,4 @@ defmodule Hound.Session do
   def set_timeout(session_id, operation, time) do
     make_req(:post, "session/#{session_id}/timeouts", %{type: operation, ms: time})
   end
-
 end

--- a/lib/hound/session_server.ex
+++ b/lib/hound/session_server.ex
@@ -9,9 +9,9 @@ defmodule Hound.SessionServer do
   end
 
 
-  def session_for_pid(pid, additional_capabilities) do
+  def session_for_pid(pid, opts) do
     current_session_id(pid) ||
-      change_current_session_for_pid(pid, :default, additional_capabilities)
+      change_current_session_for_pid(pid, :default, opts)
   end
 
 
@@ -23,8 +23,8 @@ defmodule Hound.SessionServer do
   end
 
 
-  def change_current_session_for_pid(pid, session_name, additional_capabilities) do
-    GenServer.call(@name, {:change_session, pid, session_name, additional_capabilities}, 60000)
+  def change_current_session_for_pid(pid, session_name, opts) do
+    GenServer.call(@name, {:change_session, pid, session_name, opts}, 60000)
   end
 
 
@@ -48,7 +48,7 @@ defmodule Hound.SessionServer do
   end
 
 
-  def handle_call({:change_session, pid, session_name, additional_capabilities}, _from, state) do
+  def handle_call({:change_session, pid, session_name, opts}, _from, state) do
     {:ok, driver_info} = Hound.driver_info
 
     {ref, sessions} =
@@ -64,7 +64,7 @@ defmodule Hound.SessionServer do
         {:ok, session_id} ->
           {session_id, sessions}
         :error ->
-          {:ok, session_id} = Hound.Session.create_session(driver_info[:browser], additional_capabilities)
+          {:ok, session_id} = Hound.Session.create_session(driver_info[:browser], opts)
           {session_id, Map.put(sessions, session_name, session_id)}
       end
 

--- a/test/browser_test.exs
+++ b/test/browser_test.exs
@@ -1,0 +1,34 @@
+defmodule Hound.BrowserTest do
+  use ExUnit.Case
+
+  alias Hound.Browser
+
+  test "make_capabilities for chrome" do
+    result = Browser.make_capabilities("chrome", metadata: %{"foo" => "bar"})
+    assert %{browserName: "chrome", chromeOptions: %{"args" => ["--user-agent=" <> ua]}} = result
+    assert Hound.Metadata.extract(ua) == %{"foo" => "bar"}
+  end
+
+  test "make capabilities for firefox" do
+    result = Browser.make_capabilities("firefox", metadata: %{"foo" => "bar"})
+    assert %{browserName: "firefox", firefox_profile: profile} = result
+    assert {:ok, files} = :zip.extract(Base.decode64!(profile), [:memory])
+    assert [{'user.js', user_prefs}] = files
+    assert [_, ua] = Regex.run(~r{user_pref\("general\.useragent\.override", "(.*?)"\);}, user_prefs)
+    assert Hound.Metadata.extract(ua) == %{"foo" => "bar"}
+  end
+
+  test "make_capabilities for phantomjs" do
+    result = Browser.make_capabilities("phantomjs", metadata: %{"foo" => "bar"})
+    assert %{:browserName => "phantomjs", "phantomjs.page.settings.userAgent" => ua} = result
+    assert Hound.Metadata.extract(ua) == %{"foo" => "bar"}
+  end
+
+  test "user_agent" do
+    assert Browser.user_agent(:firefox)   =~ "Firefox"
+    assert Browser.user_agent(:chrome)    =~ "Chrome"
+    assert Browser.user_agent(:iphone)    =~ "iPhone"
+    assert Browser.user_agent(:android)   =~ "Android"
+    assert Browser.user_agent(:phantomjs) =~ "PhantomJS"
+  end
+end

--- a/test/browsers/chrome_test.exs
+++ b/test/browsers/chrome_test.exs
@@ -1,0 +1,15 @@
+defmodule Hound.Browser.ChromeTest do
+  use ExUnit.Case
+
+  alias Hound.Browser.Chrome
+
+  test "default_user_agent" do
+    assert Chrome.default_user_agent == :chrome
+  end
+
+  test "user_agent_capabilities" do
+    ua = Hound.Browser.user_agent(:iphone)
+    expected = %{chromeOptions: %{"args" => ["--user-agent=#{ua}"]}}
+    assert Chrome.user_agent_capabilities(ua) == expected
+  end
+end

--- a/test/browsers/firefox/profile_test.exs
+++ b/test/browsers/firefox/profile_test.exs
@@ -1,7 +1,7 @@
-defmodule Firefox.ProfileTest do
+defmodule Hound.Browser.Firefox.ProfileTest do
   use ExUnit.Case
 
-  alias Hound.Firefox.Profile
+  alias Hound.Browser.Firefox.Profile
 
   test "new/1 returns a new Profile" do
     assert %Profile{} = Profile.new

--- a/test/browsers/firefox_test.exs
+++ b/test/browsers/firefox_test.exs
@@ -1,0 +1,17 @@
+defmodule Hound.Browser.FirefoxTest do
+  use ExUnit.Case
+
+  alias Hound.Browser.Firefox
+
+  test "default_user_agent" do
+    assert Firefox.default_user_agent == :firefox
+  end
+
+  test "user_agent_capabilities" do
+    ua = Hound.Browser.user_agent(:iphone)
+    assert %{firefox_profile: profile} = Firefox.user_agent_capabilities(ua)
+    assert {:ok, files} = :zip.extract(Base.decode64!(profile), [:memory])
+    assert [{'user.js', user_prefs}] = files
+    assert user_prefs =~ ~s<user_pref("general.useragent.override", "#{ua}");>
+  end
+end

--- a/test/browsers/phantomjs_test.exs
+++ b/test/browsers/phantomjs_test.exs
@@ -1,0 +1,14 @@
+defmodule Hound.Browser.PhantomJSTest do
+  use ExUnit.Case
+
+  alias Hound.Browser.PhantomJS
+
+  test "default_user_agent" do
+    assert PhantomJS.default_user_agent == :phantomjs
+  end
+
+  test "user_agent_capabilities" do
+    ua = Hound.Browser.user_agent(:iphone)
+    assert PhantomJS.user_agent_capabilities(ua) == %{"phantomjs.page.settings.userAgent" => ua}
+  end
+end

--- a/test/metadata_test.exs
+++ b/test/metadata_test.exs
@@ -1,0 +1,47 @@
+defmodule Hound.MetadataTest do
+  use ExUnit.Case
+
+  use Hound.Helpers
+
+  alias Hound.Metadata
+
+  @ua "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1"
+
+  test "format produces UA compatible string" do
+    assert Metadata.format(%{foo: "foo", bar: "baz"}) =~ ~r{BeamMetadata \([a-zA-Z0-9=-_]+\)}
+  end
+
+  test "extract returns empty map when no match" do
+    assert Metadata.extract(@ua) == %{}
+  end
+
+  test "extract raises when data cannot be parsed" do
+    assert_raise ArgumentError, fn ->
+      Metadata.extract("#{@ua}/BeamMetadata (some random string)")
+    end
+
+    assert_raise Hound.InvalidMetadataError, fn ->
+      bad_data = {:v123, "foobar"} |> :erlang.term_to_binary |> Base.encode64
+      Metadata.extract("#{@ua}/BeamMetadata (#{bad_data})")
+    end
+  end
+
+  test "extract returns metadata" do
+    ua = Metadata.append(@ua, %{foo: "bar", baz: "qux"})
+    assert Metadata.extract(ua) == %{foo: "bar", baz: "qux"}
+  end
+
+  test "accepts complex values" do
+    metadata = %{ref: make_ref(), pid: self(), list: [1, 2, 3]}
+    assert Metadata.extract(Metadata.append(@ua, metadata)) == metadata
+  end
+
+  test "metadata is passed to the browser through user agent" do
+    metadata = %{my_pid: self()}
+    Hound.start_session(metadata: metadata)
+    navigate_to "http://localhost:9090/page1.html"
+    ua = execute_script("return navigator.userAgent;", [])
+    assert Metadata.extract(ua) == metadata
+    Hound.end_session
+  end
+end

--- a/test/session_test.exs
+++ b/test/session_test.exs
@@ -1,0 +1,27 @@
+defmodule Hound.SessionTest do
+  use ExUnit.Case
+
+  alias Hound.Session
+
+  test "make_capabilities uses default browser" do
+    assert %{browserName: "chrome"} = Session.make_capabilities("chrome")
+  end
+
+  test "make_capabilities has default settings" do
+    assert %{takesScreenshot: true} = Session.make_capabilities("chrome")
+  end
+
+  test "make_capabilities allows browser override" do
+    assert %{browserName: "firefox"} = Session.make_capabilities("chrome", browser: "firefox")
+  end
+
+  test "make_capabilities uses driver overrides" do
+    assert %{foo: "bar"} = Session.make_capabilities("chrome", driver: %{foo: "bar"})
+  end
+
+  test "make_capabilities overrides user agent" do
+    ua = Hound.Browser.user_agent(:chrome)
+    result = Session.make_capabilities("chrome", user_agent: ua)
+    assert %{chromeOptions: %{"args" => ["--user-agent=" <> ^ua]}} = result
+  end
+end


### PR DESCRIPTION
This PR will allow us to pass custom metadata to the webdriver, through the user agent string,
which should be enough to handle the use case described in #71.

For example

```elixir
:ok = Ecto.Adapters.SQL.Sandbox.checkout(MyRepo, [])
Hound.start_session(metadata: %{parent: self()})

Task.start_link fn ->
  user_agent = conn |> get_resp_header("user-agent") |> List.first
  %{parent: parent} = Hound.Metadata.extract(user_agent)
  :ok = Ecto.Adapters.SQL.Sandbox.allow(MyRepo, parent, self())
end
```

To make this possible, additional capabilities are now passed through the `:driver` keys, which is a breaking change.

What do you think?

/cc @HashNuke @josevalim 