### PR TITLE
If we don't know what happened, pass the error along

### DIFF
--- a/lib/hound/helpers/page.ex
+++ b/lib/hound/helpers/page.ex
@@ -281,7 +281,7 @@ defmodule Hound.Helpers.Page do
   defp process_element_response({:error, :no_such_element}),
     do: nil
   defp process_element_response({:error, err}),
-    do: raise err
+    do: {:error, err}
   defp process_element_response(value),
     do: value
 end


### PR DESCRIPTION
Why:

* It is easier to work with an elixir tuple than with an exception.
* Also, I wanted to understand why raising an exception was the
  solution, and decided this was the easiest way to have that discussion

This change addresses the need by:

* Passing the error along, instead of raising an exception