### PR TITLE
Add search_element and rename find_element! to find_element.

### DIFF
--- a/lib/hound/exceptions.ex
+++ b/lib/hound/exceptions.ex
@@ -1,3 +1,7 @@
+defmodule Hound.Error do
+  defexception [:message]
+end
+
 defmodule Hound.NoSuchElementError do
   defexception [:strategy, :selector, :parent]
 

--- a/lib/hound/helpers/element.ex
+++ b/lib/hound/helpers/element.ex
@@ -304,7 +304,7 @@ defmodule Hound.Helpers.Element do
 
   @doc false
   defp get_element({strategy, selector}),
-    do: Hound.Helpers.Page.find_element!(strategy, selector)
+    do: Hound.Helpers.Page.find_element(strategy, selector)
   defp get_element(%Hound.Element{} = elem),
     do: elem
 end

--- a/test/helpers/page_test.exs
+++ b/test/helpers/page_test.exs
@@ -36,15 +36,15 @@ defmodule PageTest do
   end
 
 
-  test "find_element/3 should return nil if element does not exist" do
+  test "search_element/3 should return {:error, :no_such_element} if element does not exist" do
     navigate_to("http://localhost:9090/page1.html")
-    refute find_element(:css, ".i-dont-exist")
+    assert search_element(:css, ".i-dont-exist") == {:error, :no_such_element}
   end
 
-  test "find_element!/3 should raise NoSuchElementError if element does not exist" do
+  test "find_element/3 should raise NoSuchElementError if element does not exist" do
     navigate_to("http://localhost:9090/page1.html")
     assert_raise Hound.NoSuchElementError, fn ->
-      find_element!(:css, ".i-dont-exist")
+      find_element(:css, ".i-dont-exist")
     end
   end
 
@@ -65,16 +65,16 @@ defmodule PageTest do
     assert Element.element?(element)
   end
 
-  test "find_within_element/4 should return nil if element is not found" do
+  test "search_within_element/4 should return {:error, :no_such_element} if element is not found" do
     navigate_to("http://localhost:9090/page1.html")
     container_id = find_element(:class, "container")
-    refute find_within_element(container_id, :class, "i-dont-exist")
+    assert search_within_element(container_id, :class, "i-dont-exist") == {:error, :no_such_element}
   end
 
-  test "find_within_element!/4 should raise NoSuchElementError if element is not found" do
+  test "find_within_element/4 should raise NoSuchElementError if element is not found" do
     navigate_to("http://localhost:9090/page1.html")
     container_id = find_element(:class, "container")
-    assert_raise Hound.NoSuchElementError, fn -> find_within_element!(container_id, :class, "i-dont-exist") end
+    assert_raise Hound.NoSuchElementError, fn -> find_within_element(container_id, :class, "i-dont-exist") end
   end
 
   test "should find all elements within another element" do


### PR DESCRIPTION
I added `search_element` and restore `find_element` to its previous behavior of raising on any error.
This way, there should be no backward incompatibility here while we can still easily check for errors.