### PR TITLE
Added a note in the docs outlining difference b/w element?/2 and element_displayed?/1

### DIFF
--- a/lib/hound/helpers/element.ex
+++ b/lib/hound/helpers/element.ex
@@ -201,6 +201,9 @@ defmodule Hound.Helpers.Element do
   You can also pass the selector as a tuple.
 
       element_displayed?({:name, "example"})
+      
+  Note: If you'd like to check presence of elements in the DOM use `element?/2`, 
+  `element_displayed?/1` will only consider elements that are always present in the DOM, either in visible or hidden state.
   """
   @spec element_displayed?(Hound.Element.selector) :: :true | :false
   def element_displayed?(element) do


### PR DESCRIPTION
This tripped me up and took me some time to figure this out. Partially because `element?/2` was defined within `Hound.Matchers` and I kept looking into `Hound.Helpers.Element` for possible ways to check the presence of an element instead of it's visibility.