### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ For browser automation and writing integration tests in Elixir.
 <a href="http://github.com/HashNuke/Hound" target="_parent">Source</a> | <a href="http://hexdocs.pm/hound" target="_parent">Documentation</a>
 
 [![Build Status](https://travis-ci.org/HashNuke/hound.png?branch=master)](https://travis-ci.org/HashNuke/hound)
+[![Deps Status](https://beta.hexfaktor.org/badge/all/github/HashNuke/hound.svg)](https://beta.hexfaktor.org/github/HashNuke/hound)
 
 ## Features
 


### PR DESCRIPTION
Hi Akash,

this PR pitches my latest project for the Elixir community:

[![Deps Status](https://beta.hexfaktor.org/badge/all/github/HashNuke/hound.svg)](https://beta.hexfaktor.org/github/HashNuke/hound)

This badge shows you an analysis for your dependencies. Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released. This is still in its infancy, and I want to basically invite you to join the beta to test-drive this. 

I really believe that we can create a great service for the community with this. That said, I can imagine several reasons why you would not want to have this in your README. So don't feel any obligation, just tell me what you think!