### PR TITLE
Added default browser, so no error is thrown for non standard browser…

### DIFF
--- a/lib/hound/browser.ex
+++ b/lib/hound/browser.ex
@@ -45,6 +45,9 @@ defmodule Hound.Browser do
   def user_agent(:safari_iphone) do
     "Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25"
   end
+  def user_agent(:default) do
+    ""
+  end
 
   # add some simpler aliases
   def user_agent(:chrome),  do: user_agent(:chrome_desktop)
@@ -58,4 +61,5 @@ defmodule Hound.Browser do
   defp browser("firefox"),   do: Hound.Browser.Firefox
   defp browser("chrome"),    do: Hound.Browser.Chrome
   defp browser("phantomjs"), do: Hound.Browser.PhantomJS
+  defp browser(_),           do: Hound.Browser.Default
 end

--- a/lib/hound/browsers/default.ex
+++ b/lib/hound/browsers/default.ex
@@ -1,0 +1,9 @@
+defmodule Hound.Browser.Default do
+  @moduledoc false
+
+  @behaviour Hound.Browser
+
+  def default_user_agent, do: :default
+
+  def user_agent_capabilities(_ua), do: %{}
+end

--- a/test/browsers/default_test.exs
+++ b/test/browsers/default_test.exs
@@ -1,0 +1,14 @@
+defmodule Hound.Browser.DefaultTest do
+  use ExUnit.Case
+
+  alias Hound.Browser.Default
+
+  test "default_user_agent" do
+    assert Default.default_user_agent == :default
+  end
+
+  test "user_agent_capabilities" do
+    ua = Hound.Browser.user_agent(:iphone)
+    assert Default.user_agent_capabilities(ua) == %{}
+  end
+end


### PR DESCRIPTION
Hi,

When attempting to create session for some non-standard like for example "internet explorer" an matching exception is thrown `no function clause matching in Hound.Browser.browser`.

I created a fallback default browser so the user is able to create a session with whatever browserName he chooses to use. If selenium webdriver does not support such browser then it will fail.

Best regards,
Krzysztof Mochejski
