### PR TITLE
Drop dependency on httpoison, use hackney directly

### DIFF
--- a/lib/hound/response_parser.ex
+++ b/lib/hound/response_parser.ex
@@ -15,11 +15,6 @@ defmodule Hound.ResponseParser do
 
       @before_compile unquote(__MODULE__)
 
-      def parse(path, %HTTPoison.Response{body: raw_content, status_code: code}) do
-        body = Hound.ResponseParser.decode_content(raw_content)
-        handle_response(path, code, body)
-      end
-
       def handle_response(path, code, body) do
         Hound.ResponseParser.handle_response(__MODULE__, path, code, body)
       end
@@ -28,6 +23,11 @@ defmodule Hound.ResponseParser do
 
       defoverridable [handle_response: 3, warning?: 1]
     end
+  end
+
+  def parse(parser, path, code, _headers, raw_content) do
+    body = Hound.ResponseParser.decode_content(raw_content)
+    parser.handle_response(path, code, body)
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Hound.Mixfile do
 
   def application do
     [
-      applications: [:hackney, :httpoison, :logger],
+      applications: [:hackney, :poison, :logger],
       mod: { Hound, [] },
       description: 'Integration testing and browser automation library',
     ]
@@ -27,7 +27,7 @@ defmodule Hound.Mixfile do
 
   defp deps do
     [
-      {:httpoison, "~> 0.8"},
+      {:hackney, "~> 1.5"},
       {:poison,    ">= 1.4.0"},
       {:earmark, "~> 0.1.17 or ~> 0.2", only: :docs},
       {:ex_doc,  "~> 0.11.0", only: :docs}

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,9 @@
-%{"certifi": {:hex, :certifi, "0.3.0", "389d4b126a47895fe96d65fcf8681f4d09eca1153dc2243ed6babad0aac1e763", [:rebar3], []},
+%{"certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.11.3", "bb16cb3f4135d880ce25279dc19a9d70802bc4f4942f0c3de9e4862517ae3ace", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
-  "hackney": {:hex, :hackney, "1.4.6", "dcef5aa50e01d41379b410f02b51c1b2a9072b1cf24b85774bb2bc721455964f", [:rebar3], [{:ssl_verify_hostname, "1.0.5", [hex: :ssl_verify_hostname, optional: false]}, {:mimerl, "1.0.0", [hex: :mimerl, optional: false]}, {:idna, "1.0.2", [hex: :idna, optional: false]}, {:certifi, "0.3.0", [hex: :certifi, optional: false]}]},
-  "httpoison": {:hex, :httpoison, "0.8.0", "52a958d40b2aa46da418cdf6d8dfd82ba83e94d5e60920dfa5f40c05b34fe073", [:mix], [{:hackney, "~> 1.4.4", [hex: :hackney, optional: false]}]},
-  "idna": {:hex, :idna, "1.0.2", "397e3d001c002319da75759b0a81156bf11849c71d565162436d50020cb7265e", [:make], []},
-  "mimerl": {:hex, :mimerl, "1.0.0", "b9813e0fa1019420da8c8001748d7c34791fd49464cb28762bc22638b1ff6198", [:rebar3], []},
+  "hackney": {:hex, :hackney, "1.6.1", "ddd22d42db2b50e6a155439c8811b8f6df61a4395de10509714ad2751c6da817", [:rebar3], [{:certifi, "0.4.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}]},
+  "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
+  "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
+  "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "poison": {:hex, :poison, "1.5.2", "560bdfb7449e3ddd23a096929fb9fc2122f709bcc758b2d5d5a5c7d0ea848910", [:mix], []},
-  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5", "2e73e068cd6393526f9fa6d399353d7c9477d6886ba005f323b592d389fb47be", [:make], []}}
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []}}

--- a/test/response_parser_test.exs
+++ b/test/response_parser_test.exs
@@ -1,6 +1,8 @@
 defmodule ResponseParserTest do
   use ExUnit.Case
 
+  alias Hound.ResponseParser
+
   defmodule DummyParser do
     use Hound.ResponseParser
   end
@@ -14,8 +16,8 @@ defmodule ResponseParserTest do
   end
 
   test "parse/2" do
-    response = %HTTPoison.Response{status_code: 200, body: ~s({"sessionId": 1})}
-    assert DummyParser.parse("session", response) == {:ok, 1}
+    body = ~s({"sessionId": 1})
+    assert ResponseParser.parse(DummyParser, "session", 200, [], body) == {:ok, 1}
   end
 
   test "handle_response/3 session" do


### PR DESCRIPTION
This removes one dependency from the project, and I don't think it complicates it in any significant way.

I had some issues running tests, please check if this is sound.

I also removed the `parse/2` function out of the response parsers, it wasn't one of the callbacks, so I assumed it wasn't public API. Please let me know if you want it back.