### PR TITLE
config example directly into the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,13 @@ When you run `mix test`, Hound is automatically started. __You'll need a webdriv
 
 ## Configure
 
-To configure Hound, use your `config/config.exs` file or equivalent. [Examples are here](https://github.com/HashNuke/hound/blob/master/notes/configuring-hound.md).
+To configure Hound, use your `config/config.exs` file or equivalent. 
+
+Example:
+
+```config :hound, driver: "phantomjs"```
+
+[More examples here](https://github.com/HashNuke/hound/blob/master/notes/configuring-hound.md).
 
 ## Usage
 


### PR DESCRIPTION
How about adding an actual config example directly into the readme?
I'm probably not the first one missing that this is needed, regardless of which driver one actually wants to use.

I believe this can be helpful to people looking through the readme for a quickstart setup.