### PR TITLE
Save page

### DIFF
--- a/lib/hound/helpers.ex
+++ b/lib/hound/helpers.ex
@@ -11,6 +11,7 @@ defmodule Hound.Helpers do
       import Hound.Helpers.Orientation
       import Hound.Helpers.Page
       import Hound.Helpers.Screenshot
+      import Hound.Helpers.SavePage
       import Hound.Helpers.ScriptExecution
       import Hound.Helpers.Session
       import Hound.Helpers.Window

--- a/lib/hound/helpers/save_page.ex
+++ b/lib/hound/helpers/save_page.ex
@@ -1,0 +1,36 @@
+defmodule Hound.Helpers.SavePage do
+  @moduledoc "Provides helper function to save the current page"
+
+  import Hound.RequestUtils
+
+  @doc """
+  Save the dom of the current page. The page is saved in the current working directory.
+  It returns the path of the html file, to which the dom has been saved.
+
+  For Elixir mix projects, the saved screenshot can be found in the root of the project directory.
+
+      save_page()
+
+  You can also pass a file path to which the screenshot must be saved to.
+
+      # Pass a full file path
+      save_page("/media/pages/test.html")
+
+      # Or you can also pass a path relative to the current directory. save_page("page.html")
+  """
+  @spec save_page(String.t) :: String.t
+  def save_page(path \\ default_path) do
+    session_id = Hound.current_session_id
+    page_data = make_req(:get, "session/#{session_id}/source")
+
+    :ok = File.write path, page_data
+    path
+  end
+
+  defp default_path do
+    {{year, month, day}, {hour, minutes, seconds}} = :erlang.localtime()
+    cwd = File.cwd!()
+    "#{cwd}/page-#{year}-#{month}-#{day}-#{hour}-#{minutes}-#{seconds}.html"
+  end
+
+end

--- a/mix.lock
+++ b/mix.lock
@@ -6,4 +6,4 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "poison": {:hex, :poison, "1.5.2", "560bdfb7449e3ddd23a096929fb9fc2122f709bcc758b2d5d5a5c7d0ea848910", [:mix], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []}}
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:make, :rebar], []}}

--- a/test/helpers/save_page_test.exs
+++ b/test/helpers/save_page_test.exs
@@ -1,0 +1,13 @@
+defmodule SavePageTest do
+  use ExUnit.Case
+  use Hound.Helpers
+
+  hound_session
+
+  test "should save the page" do
+    navigate_to("http://localhost:9090/page1.html")
+    path = save_page("screenshot-test.html")
+    assert File.exists?(path)
+  end
+
+end


### PR DESCRIPTION
Motivation:
  - Create the ability to save a page much like we save a screenshot.
    relates to HashNuke/hound/issues/131
Changes:
  - Add a save page helper.
  - Add tests.