### PR TITLE
Add basic session log support

### DIFF
--- a/lib/hound/session.ex
+++ b/lib/hound/session.ex
@@ -65,4 +65,18 @@ defmodule Hound.Session do
   def set_timeout(session_id, operation, time) do
     make_req(:post, "session/#{session_id}/timeouts", %{type: operation, ms: time})
   end
+
+
+  @doc "Get the session log for a particular log type"
+  @spec fetch_log(String.t, String.t) :: :ok
+  def fetch_log(session_id, logtype) do
+    make_req(:post, "session/#{session_id}/log", %{type: logtype})
+  end
+
+
+  @doc "Get a list of all supported log types"
+  @spec fetch_log_types(String.t) :: :ok
+  def fetch_log_types(session_id) do
+    make_req(:get, "session/#{session_id}/log/types")
+  end
 end


### PR DESCRIPTION
Hound already contains a helper to fetch browser logs (console.log output), but this doesn't cover more advanced use cases, like the performance logging implemented in Google Chrome exposed over the log feature trough ChromeDriver (https://sites.google.com/a/chromium.org/chromedriver/logging/performance-log) or the browser driver log 

This PR adds two generic functions to fetch logs of a specific type and a list of all supported log types for a particular session.