### PR TITLE
Use parentheses for zero-arity functions

### DIFF
--- a/lib/hound/exceptions.ex
+++ b/lib/hound/exceptions.ex
@@ -33,7 +33,7 @@ defmodule Hound.NotSupportedError do
                  {func, arity} -> "#{func}/#{arity}"
                  func          -> to_string(func)
                end
-    quote bind_quoted: binding do
+    quote bind_quoted: binding() do
       Hound.NotSupportedError.raise_for(params, function)
     end
   end

--- a/lib/hound/helpers/navigation.ex
+++ b/lib/hound/helpers/navigation.ex
@@ -12,7 +12,7 @@ defmodule Hound.Helpers.Navigation do
 
   @doc "Gets the path of the current page."
   def current_path do
-    URI.parse(current_url).path
+    URI.parse(current_url()).path
   end
 
   @doc """

--- a/lib/hound/helpers/save_page.ex
+++ b/lib/hound/helpers/save_page.ex
@@ -19,7 +19,7 @@ defmodule Hound.Helpers.SavePage do
       # Or you can also pass a path relative to the current directory. save_page("page.html")
   """
   @spec save_page(String.t) :: String.t
-  def save_page(path \\ default_path) do
+  def save_page(path \\ default_path()) do
     session_id = Hound.current_session_id
     page_data = make_req(:get, "session/#{session_id}/source")
 

--- a/lib/hound/helpers/screenshot.ex
+++ b/lib/hound/helpers/screenshot.ex
@@ -19,7 +19,7 @@ defmodule Hound.Helpers.Screenshot do
       # Or you can also pass a path relative to the current directory. take_screenshot("screenshot-test.png")
   """
   @spec take_screenshot(String.t) :: String.t
-  def take_screenshot(path \\ default_path) do
+  def take_screenshot(path \\ default_path()) do
     session_id = Hound.current_session_id
     base64_png_data = make_req(:get, "session/#{session_id}/screenshot")
     binary_image_data = :base64.decode(base64_png_data)

--- a/lib/hound/helpers/session.ex
+++ b/lib/hound/helpers/session.ex
@@ -14,7 +14,7 @@ defmodule Hound.Helpers.Session do
   The name can be an atom or a string. The default session created is called `:default`.
   """
   def change_session_to(session_name, opts \\ []) do
-    Hound.SessionServer.change_current_session_for_pid(self, session_name, opts)
+    Hound.SessionServer.change_current_session_for_pid(self(), session_name, opts)
   end
 
 
@@ -40,7 +40,7 @@ defmodule Hound.Helpers.Session do
       end
   """
   def in_browser_session(session_name, func) do
-    previous_session_name = current_session_name
+    previous_session_name = current_session_name()
     change_session_to(session_name)
     result = apply(func, [])
     change_session_to(previous_session_name)
@@ -94,7 +94,7 @@ defmodule Hound.Helpers.Session do
     * `:driver` - The additional capabilities to be passed directly to the webdriver.
   """
   def start_session(opts \\ []) do
-    Hound.SessionServer.session_for_pid(self, opts)
+    Hound.SessionServer.session_for_pid(self(), opts)
   end
 
 
@@ -110,15 +110,15 @@ defmodule Hound.Helpers.Session do
 
   @doc false
   def current_session_id do
-    Hound.SessionServer.current_session_id(self) ||
-      raise "could not find a session for process #{inspect self}"
+    Hound.SessionServer.current_session_id(self()) ||
+      raise "could not find a session for process #{inspect self()}"
   end
 
 
   @doc false
   def current_session_name do
-      Hound.SessionServer.current_session_name(self) ||
-        raise "could not find a session for process #{inspect self}"
+      Hound.SessionServer.current_session_name(self()) ||
+        raise "could not find a session for process #{inspect self()}"
 
 
   end

--- a/mix.exs
+++ b/mix.exs
@@ -9,8 +9,8 @@ defmodule Hound.Mixfile do
       elixir: ">= 1.0.4",
       description: "Webdriver library for integration testing and browser automation",
       source_url: "https://github.com/HashNuke/hound",
-      deps: deps,
-      package: package,
+      deps: deps(),
+      package: package(),
       docs: [source_ref: "#{@version}", extras: ["README.md"], main: "readme"]
     ]
   end


### PR DESCRIPTION
Compiler warns about this in Elixir 1.4
https://github.com/christopheradams/elixir_style_guide#parentheses-and-functions-with-zero-arity