### PR TITLE
Fixed Poison.SyntaxError when receiving 204 response

### DIFF
--- a/lib/hound/response_parser.ex
+++ b/lib/hound/response_parser.ex
@@ -25,6 +25,10 @@ defmodule Hound.ResponseParser do
     end
   end
 
+  def parse(parser, path, code = 204, _headers, raw_content = "") do
+    # Don't try to parse the json because there is none.
+    parser.handle_response(path, code, raw_content)
+  end
   def parse(parser, path, code, _headers, raw_content) do
     body = Hound.ResponseParser.decode_content(raw_content)
     parser.handle_response(path, code, body)

--- a/test/response_parser_test.exs
+++ b/test/response_parser_test.exs
@@ -20,6 +20,10 @@ defmodule ResponseParserTest do
     assert ResponseParser.parse(DummyParser, "session", 200, [], body) == {:ok, 1}
   end
 
+  test "parse/2 with 204 no-content response" do
+    assert ResponseParser.parse(DummyParser, "session", 204, [], "") == :ok
+  end
+
   test "handle_response/3 session" do
     assert DummyParser.handle_response("session", 200, %{"sessionId" => 1}) == {:ok, 1}
     assert DummyParser.handle_response("session", 400, %{"sessionId" => 1}) == :error


### PR DESCRIPTION
I was using hound's `navigate_to` helper on BrowserStack's Amazon KindleFire 2 device, and was receiving a `204 No Content` response after a `POST /session/<session_id>/url` request that changes the page. Since the request succeeded, it seems Hound should be able to handle the response
without throwing the following error:

```
Unexpected end of input at position 0
  (poison) lib/poison/parser.ex:55: Poison.Parser.parse!/2
  (poison) lib/poison.ex:83: Poison.decode!/2
  (hound) lib/hound/response_parser.ex:29: Hound.ResponseParser.parse/5
  (hound) lib/hound/request_utils.ex:48: Hound.RequestUtils.handle_response/3
```

This change just skips the response parsing if the status code is 204 and the raw content is empty (which it should be).