### PR TITLE
Add mouse events

### DIFF
--- a/lib/hound/helpers.ex
+++ b/lib/hound/helpers.ex
@@ -16,6 +16,7 @@ defmodule Hound.Helpers do
       import Hound.Helpers.Session
       import Hound.Helpers.Window
       import Hound.Helpers.Log
+      import Hound.Helpers.Mouse
       import Hound.Matchers
       import unquote(__MODULE__)
     end

--- a/lib/hound/helpers/element.ex
+++ b/lib/hound/helpers/element.ex
@@ -288,6 +288,24 @@ defmodule Hound.Helpers.Element do
 
 
   @doc """
+  Moves the mouse to a given position within the given element. X and Y are relatively to the element
+  and start from top left.
+
+      element = find_element(:id, "example")
+      move_to(element, 10, 10)
+
+  You can also directly pass the selector as a tuple.
+
+      move_to({:id, "example"}, 10, 10)
+  """
+  @spec move_to(Hound.Element.selector, integer, integer) :: :ok
+  def move_to(element, xoffset, yoffset) do
+    element = get_element(element)
+    session_id = Hound.current_session_id
+    make_req(:post, "session/#{session_id}/moveto", %{element: element.uuid, xoffset: xoffset, yoffset: yoffset})
+  end
+
+  @doc """
   Sends a submit event to any field or form element.
 
       element = find_element(:name, "username")

--- a/lib/hound/helpers/mouse.ex
+++ b/lib/hound/helpers/mouse.ex
@@ -1,0 +1,36 @@
+defmodule Hound.Helpers.Mouse do
+  @moduledoc "Functions to work with the mouse"
+
+  import Hound.RequestUtils
+
+  @doc """
+  Triggers a mousedown event on the current position of the mouse, which can be set through `Helpers.Element.move_to/3`.
+  The mousedown event can get triggered with three different "buttons":
+    1. Primary Button = 0 which is the default (in general, the left button)
+    2. Auxiliary Button = 1 (in general, the middle button)
+    3. Secondary Button = 2 (in general, the right button)
+
+      mouse_down()
+  """
+  @spec mouse_down(integer) :: :ok
+  def mouse_down(button \\ 0) do
+    session_id = Hound.current_session_id
+    make_req(:post, "session/#{session_id}/buttondown", %{button: button})
+  end
+
+
+  @doc """
+  Triggers a mouseup event on the current position of the mouse, which can be set through `Helpers.Element.move_to/3`.
+  The mouseup event can get triggered with three different "buttons":
+    1. Primary Button = 0 which is the default (in general, the left button)
+    2. Auxiliary Button = 1 (in general, the middle button)
+    3. Secondary Button = 2 (in general, the right button)
+
+      mouse_up()
+  """
+  @spec mouse_up(integer) :: :ok
+  def mouse_up(button \\ 0) do
+    session_id = Hound.current_session_id
+    make_req(:post, "session/#{session_id}/buttonup", %{button: button})
+  end
+end

--- a/test/helpers/element_with_ids_test.exs
+++ b/test/helpers/element_with_ids_test.exs
@@ -141,4 +141,29 @@ defmodule ElementTestWithIds do
     submit_element(element)
     assert current_url() == "http://localhost:9090/page2.html"
   end
+
+  test "should move mouse to an element" do
+    navigate_to "http://localhost:9090/page1.html"
+    element = find_element(:id, "mouse-actions")
+    move_to(element, 5, 5)
+    assert visible_text({:id, "mouse-actions"}) == "Mouse over"
+  end
+
+  test "should mouse down on an element" do
+    navigate_to "http://localhost:9090/page1.html"
+    element = find_element(:id, "mouse-actions")
+    move_to(element, 5, 5)
+    mouse_down()
+    assert visible_text({:id, "mouse-actions"}) == "Mouse down"
+  end
+
+  test "should mouse up on an element" do
+    navigate_to "http://localhost:9090/page1.html"
+    element = find_element(:id, "mouse-actions")
+    move_to(element, 5, 5)
+    # Mouse up needs a mouse down before
+    mouse_down()
+    mouse_up()
+    assert visible_text({:id, "mouse-actions"}) == "Mouse up"
+  end
 end

--- a/test/helpers/element_with_selectors_test.exs
+++ b/test/helpers/element_with_selectors_test.exs
@@ -151,4 +151,27 @@ defmodule ElementWithSelectorsTest do
     submit_element({:name, "username"})
     assert current_url() == "http://localhost:9090/page2.html"
   end
+
+
+  test "should move mouse to an element" do
+    navigate_to "http://localhost:9090/page1.html"
+    move_to({:id, "mouse-actions"}, 5, 5)
+    assert visible_text({:id, "mouse-actions"}) == "Mouse over"
+  end
+
+  test "should mouse down on an element" do
+    navigate_to "http://localhost:9090/page1.html"
+    move_to({:id, "mouse-actions"}, 5, 5)
+    mouse_down()
+    assert visible_text({:id, "mouse-actions"}) == "Mouse down"
+  end
+
+  test "should mouse up on an element" do
+    navigate_to "http://localhost:9090/page1.html"
+    move_to({:id, "mouse-actions"}, 5, 5)
+    # Mouse up needs a mouse down before
+    mouse_down()
+    mouse_up()
+    assert visible_text({:id, "mouse-actions"}) == "Mouse up"
+  end
 end

--- a/test/sample_pages/page1.html
+++ b/test/sample_pages/page1.html
@@ -52,6 +52,9 @@
     <p class="hidden-element">This is hidden</p>
   </div>
 
+  <div id="mouse-actions">
+    I need action
+  </div>
 
   <iframe width=300 height=300 src="iframe.html"></iframe>
   <div id="javascript"></div>
@@ -59,6 +62,20 @@
     setTimeout(function (){
       document.getElementById("javascript").innerHTML = "Javascript!";
     }, 500);
+
+    var mouseActions = document.getElementById("mouse-actions")
+
+    mouseActions.onmouseover = function() {
+      mouseActions.innerHTML = "Mouse over"
+    }
+
+    mouseActions.onmousedown = function() {
+      mouseActions.innerHTML = "Mouse down"
+    }
+
+    mouseActions.onmouseup = function() {
+      mouseActions.innerHTML = "Mouse up"
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
This adds three new events:
For the element helper:
- `move_to` which takes an element and a x and y offset

And for the new mouse helper:
- `mouse_down`
- `mouse_up`
Both can optionatlly get passed an integer 0,1,2 to define which
mouse button triggered the event.

Open to change anything - wasn't particularly sure if `move_to` should get into the `Mouse` module. Also not completely sold on the tests for it, but didn't have another idea how to test those events otherwise.

