### PR TITLE
Make sure that the session is ended after the test exists

### DIFF
--- a/lib/hound/helpers.ex
+++ b/lib/hound/helpers.ex
@@ -27,6 +27,8 @@ defmodule Hound.Helpers do
     quote do
       setup do
         Hound.start_session(unquote(opts))
+        parent = self()
+        on_exit(fn -> Hound.end_session(parent) end)
 
         :ok
       end


### PR DESCRIPTION
The internal [`hound_test.exs`](https://github.com/HashNuke/hound/blob/master/test/hound_test.exs#L5) script takes care of ending the session once the test exits. The exposed helper macro, however, does not. This adds exit trapping to the helper macro as well. 