### PR TITLE
Allow to define a custom directory for screenshots/pages

### DIFF
--- a/lib/hound/connection_server.ex
+++ b/lib/hound/connection_server.ex
@@ -30,7 +30,8 @@ defmodule Hound.ConnectionServer do
 
     configs = %{
       :host => options[:app_host] || Application.get_env(:hound, :app_host, "http://localhost"),
-      :port => options[:app_port] || Application.get_env(:hound, :app_port, 4001)
+      :port => options[:app_port] || Application.get_env(:hound, :app_port, 4001),
+      :temp_dir => options[:temp_dir] || Application.get_env(:hound, :temp_dir, File.cwd!)
     }
 
     state = %{sessions: [], driver_info: driver_info, configs: configs}

--- a/lib/hound/helpers/save_page.ex
+++ b/lib/hound/helpers/save_page.ex
@@ -28,9 +28,7 @@ defmodule Hound.Helpers.SavePage do
   end
 
   defp default_path do
-    {{year, month, day}, {hour, minutes, seconds}} = :erlang.localtime()
-    cwd = File.cwd!()
-    "#{cwd}/page-#{year}-#{month}-#{day}-#{hour}-#{minutes}-#{seconds}.html"
+    Hound.Utils.temp_file_path("page", "html")
   end
 
 end

--- a/lib/hound/helpers/screenshot.ex
+++ b/lib/hound/helpers/screenshot.ex
@@ -29,9 +29,7 @@ defmodule Hound.Helpers.Screenshot do
   end
 
   defp default_path do
-    {{year, month, day}, {hour, minutes, seconds}} = :erlang.localtime()
-    cwd = File.cwd!()
-    "#{cwd}/screenshot-#{year}-#{month}-#{day}-#{hour}-#{minutes}-#{seconds}.png"
+    Hound.Utils.temp_file_path("screenshot", "png")
   end
 
 end

--- a/lib/hound/utils.ex
+++ b/lib/hound/utils.ex
@@ -1,0 +1,9 @@
+defmodule Hound.Utils do
+  @moduledoc false
+
+  def temp_file_path(prefix, extension) do
+    {{year, month, day}, {hour, minutes, seconds}} = :erlang.localtime()
+    {:ok, configs} = Hound.configs
+    "#{configs[:temp_dir]}/#{prefix}-#{year}-#{month}-#{day}-#{hour}-#{minutes}-#{seconds}.#{extension}"
+  end
+end


### PR DESCRIPTION
This PR adds a new configuration option `temp_dir` to define a directory where all screenshots (`take_screenshot`) and pages (`save_page`) should be saved to.

#### No `temp_dir` (default)

```elixir
config :hound,
  host: "http://localhost",
  port: 4001

{:ok, configs} = Hound.configs

configs[:temp_dir] # /home/jan/Workspace/example
take_screenshot()  # /home/jan/Workspace/example/screenshot-2017-6-1-17-56-36.png
save_page()        # /home/jan/Workspace/example/page-2017-6-1-17-56-36.html
```

As you can see, the default temp directory is the same as before this change (`File.cwd!`)

#### Custom `temp_dir`

```elixir
config :hound,
  host: "http://localhost",
  port: 4001,
  temp_dir: "#{File.cwd!}/tmp/hound"

{:ok, configs} = Hound.configs

configs[:temp_dir] # /home/jan/Workspace/example/tmp/hound
take_screenshot()  # /home/jan/Workspace/example/tmp/hound/screenshot-2017-6-1-17-56-36.png
save_page()        # /home/jan/Workspace/example/tmp/hound/page-2017-6-1-17-56-36.html
```