### PR TITLE
Add support for Chrome in headless mode via ChromeDriver (implements #135)

### DIFF
--- a/lib/hound/browser.ex
+++ b/lib/hound/browser.ex
@@ -5,7 +5,7 @@ defmodule Hound.Browser do
 
   @callback default_user_agent :: String.t | atom
 
-  @callback user_agent_capabilities(String.t) :: map
+  @callback default_capabilities(String.t) :: map
 
   @doc "Creates capabilities for the browser and options, to be sent to the webdriver"
   @spec make_capabilities(t, map | Keyword.t) :: map
@@ -17,11 +17,11 @@ defmodule Hound.Browser do
       |> Hound.Metadata.append(opts[:metadata])
 
     capabilities = %{browserName: browser_name}
-    ua_capabilities = browser.user_agent_capabilities(user_agent)
+    default_capabilities = browser.default_capabilities(user_agent)
     additional_capabilities = opts[:additional_capabilities] || %{}
 
     capabilities
-    |> Map.merge(ua_capabilities)
+    |> Map.merge(default_capabilities)
     |> Map.merge(additional_capabilities)
   end
 
@@ -61,8 +61,9 @@ defmodule Hound.Browser do
   defp browser(browser) when is_atom(browser) do
     browser |> Atom.to_string |> browser()
   end
-  defp browser("firefox"),   do: Hound.Browser.Firefox
-  defp browser("chrome"),    do: Hound.Browser.Chrome
-  defp browser("phantomjs"), do: Hound.Browser.PhantomJS
-  defp browser(_),           do: Hound.Browser.Default
+  defp browser("firefox"),          do: Hound.Browser.Firefox
+  defp browser("chrome"),           do: Hound.Browser.Chrome
+  defp browser("chrome_headless"),  do: Hound.Browser.ChromeHeadless
+  defp browser("phantomjs"),        do: Hound.Browser.PhantomJS
+  defp browser(_),                  do: Hound.Browser.Default
 end

--- a/lib/hound/browsers/chrome.ex
+++ b/lib/hound/browsers/chrome.ex
@@ -5,7 +5,7 @@ defmodule Hound.Browser.Chrome do
 
   def default_user_agent, do: :chrome
 
-  def user_agent_capabilities(ua) do
+  def default_capabilities(ua) do
     %{chromeOptions: %{"args" => ["--user-agent=#{ua}"]}}
   end
 end

--- a/lib/hound/browsers/chrome_headless.ex
+++ b/lib/hound/browsers/chrome_headless.ex
@@ -1,0 +1,11 @@
+defmodule Hound.Browser.ChromeHeadless do
+  @moduledoc false
+
+  @behaviour Hound.Browser
+
+  def default_user_agent, do: :chrome
+
+  def default_capabilities(ua) do
+    %{chromeOptions: %{"args" => ["--user-agent=#{ua}", "--headless", "--disable-gpu"]}}        
+  end
+end

--- a/lib/hound/browsers/default.ex
+++ b/lib/hound/browsers/default.ex
@@ -5,5 +5,5 @@ defmodule Hound.Browser.Default do
 
   def default_user_agent, do: :default
 
-  def user_agent_capabilities(_ua), do: %{}
+  def default_capabilities(_ua), do: %{}
 end

--- a/lib/hound/browsers/firefox.ex
+++ b/lib/hound/browsers/firefox.ex
@@ -7,7 +7,7 @@ defmodule Hound.Browser.Firefox do
 
   def default_user_agent, do: :firefox
 
-  def user_agent_capabilities(ua) do
+  def default_capabilities(ua) do
     {:ok, profile} = Profile.new |> Profile.set_user_agent(ua) |> Profile.dump
     %{firefox_profile: profile}
   end

--- a/lib/hound/browsers/phantomjs.ex
+++ b/lib/hound/browsers/phantomjs.ex
@@ -5,7 +5,7 @@ defmodule Hound.Browser.PhantomJS do
 
   def default_user_agent, do: :phantomjs
 
-  def user_agent_capabilities(ua) do
+  def default_capabilities(ua) do
     %{"phantomjs.page.settings.userAgent" => ua}
   end
 end

--- a/lib/hound/helpers/session.ex
+++ b/lib/hound/helpers/session.ex
@@ -81,7 +81,7 @@ defmodule Hound.Helpers.Session do
 
   The following options can be passed to `start_session`:
 
-    * `:browser` - The browser to be used (`"chrome"` | `"phantomjs"` | `"firefox"`)
+    * `:browser` - The browser to be used (`"chrome"` | `"chrome_headless"` | `"phantomjs"` | `"firefox"`)
     * `:user_agent` - The user agent string that will be used for the requests.
       The following atoms can also be passed
         * `:firefox_desktop` (aliased to `:firefox`)

--- a/notes/configuring-hound.md
+++ b/notes/configuring-hound.md
@@ -28,6 +28,11 @@ config :hound, driver: "chrome_driver"
 ```
 
 ```elixir
+# Use Chrome in headless mode with ChromeDriver (default port 9515 assumed) 
+config :hound, driver: "chrome_driver", browser: "chrome_headless"
+```
+
+```elixir
 # Start Hound for remote PhantomJs server at port 5555
 config :hound, driver: "phantomjs", host: "http://example.com", port: 5555
 ```

--- a/test/browsers/chrome_headless_test.exs
+++ b/test/browsers/chrome_headless_test.exs
@@ -1,0 +1,15 @@
+defmodule Hound.Browser.ChromeHeadlessTest do
+  use ExUnit.Case
+
+  alias Hound.Browser.ChromeHeadless
+
+  test "default_user_agent" do
+    assert ChromeHeadless.default_user_agent == :chrome
+  end
+
+  test "default_capabilities" do
+    ua = Hound.Browser.user_agent(:iphone)
+    expected = %{chromeOptions: %{"args" => ["--user-agent=#{ua}", "--headless", "--disable-gpu"]}}
+    assert ChromeHeadless.default_capabilities(ua) == expected
+  end
+end

--- a/test/browsers/chrome_test.exs
+++ b/test/browsers/chrome_test.exs
@@ -7,9 +7,9 @@ defmodule Hound.Browser.ChromeTest do
     assert Chrome.default_user_agent == :chrome
   end
 
-  test "user_agent_capabilities" do
+  test "default_capabilities" do
     ua = Hound.Browser.user_agent(:iphone)
     expected = %{chromeOptions: %{"args" => ["--user-agent=#{ua}"]}}
-    assert Chrome.user_agent_capabilities(ua) == expected
+    assert Chrome.default_capabilities(ua) == expected
   end
 end

--- a/test/browsers/default_test.exs
+++ b/test/browsers/default_test.exs
@@ -7,8 +7,8 @@ defmodule Hound.Browser.DefaultTest do
     assert Default.default_user_agent == :default
   end
 
-  test "user_agent_capabilities" do
+  test "default_capabilities" do
     ua = Hound.Browser.user_agent(:iphone)
-    assert Default.user_agent_capabilities(ua) == %{}
+    assert Default.default_capabilities(ua) == %{}
   end
 end

--- a/test/browsers/firefox_test.exs
+++ b/test/browsers/firefox_test.exs
@@ -7,9 +7,9 @@ defmodule Hound.Browser.FirefoxTest do
     assert Firefox.default_user_agent == :firefox
   end
 
-  test "user_agent_capabilities" do
+  test "default_capabilities" do
     ua = Hound.Browser.user_agent(:iphone)
-    assert %{firefox_profile: profile} = Firefox.user_agent_capabilities(ua)
+    assert %{firefox_profile: profile} = Firefox.default_capabilities(ua)
     assert {:ok, files} = :zip.extract(Base.decode64!(profile), [:memory])
     assert [{'user.js', user_prefs}] = files
     assert user_prefs =~ ~s<user_pref("general.useragent.override", "#{ua}");>

--- a/test/browsers/phantomjs_test.exs
+++ b/test/browsers/phantomjs_test.exs
@@ -7,8 +7,8 @@ defmodule Hound.Browser.PhantomJSTest do
     assert PhantomJS.default_user_agent == :phantomjs
   end
 
-  test "user_agent_capabilities" do
+  test "default_capabilities" do
     ua = Hound.Browser.user_agent(:iphone)
-    assert PhantomJS.user_agent_capabilities(ua) == %{"phantomjs.page.settings.userAgent" => ua}
+    assert PhantomJS.default_capabilities(ua) == %{"phantomjs.page.settings.userAgent" => ua}
   end
 end


### PR DESCRIPTION
To implement #135  i've created a new browser :chrome_headless, renamed the ua_capabilities to a more generic default_capabilities and added the needed parameters for chrome headless to the default_capabilities.