### PR TITLE
- add a setting parameter which sets genserver timeout

### DIFF
--- a/lib/hound/session_server.ex
+++ b/lib/hound/session_server.ex
@@ -35,7 +35,7 @@ defmodule Hound.SessionServer do
 
 
   def change_current_session_for_pid(pid, session_name, opts) do
-    GenServer.call(@name, {:change_session, pid, session_name, opts}, 60000)
+    GenServer.call(@name, {:change_session, pid, session_name, opts}, genserver_timeout())
   end
 
 
@@ -108,5 +108,9 @@ defmodule Hound.SessionServer do
     Enum.each sessions, fn({_session_name, session_id})->
       Hound.Session.destroy_session(session_id)
     end
+  end
+
+  defp genserver_timeout() do
+    Application.get_env(:hound, :genserver_timeout, 60000)
   end
 end

--- a/notes/configuring-hound.md
+++ b/notes/configuring-hound.md
@@ -60,3 +60,8 @@ config :hound,
   port: 32770,
   path_prefix: "wd/hub/"
 ```
+
+```elixir
+# Set genserver timeout
+config :hound, genserver_timeout: 480000
+```


### PR DESCRIPTION
I was using Saucelabs for a mobile test automation. They use Appium and it normally takes a few minutes to go through the test and takes about 3 minutes to prepare the test. I created a new configuration that sets genserver timeout because a minute is too short for this kind of task. Without the explicit setting it will be set as 1 minute as before.