### PR TITLE
301, 302, 303 (only POST), 307 redirections

### DIFF
--- a/lib/hound/session.ex
+++ b/lib/hound/session.ex
@@ -25,8 +25,8 @@ defmodule Hound.Session do
       desiredCapabilities: capabilities
     }
 
-    # No retries for this request
-    make_req(:post, "session", params)
+    # 301, 302, 303 (only POST), 307 redirections need at least one retry for hackney to follow it.
+    make_req(:post, "session", params, 1)
   end
 
   @doc "Make capabilities for session"


### PR DESCRIPTION
301, 302, 303 (only POST), 307 redirections need at least one retry for Hackney (Hound's HTTP library) to follow it.
Sauce labs appium tests respond with 303 redirection and without Hackney's following it, the tests will crash.