### PR TITLE
301, 302, 303 (only POST), 307 redirections

### DIFF
--- a/lib/hound/session.ex
+++ b/lib/hound/session.ex
@@ -25,8 +25,8 @@ defmodule Hound.Session do
       desiredCapabilities: capabilities
     }
 
-    # No retries for this request
-    make_req(:post, "session", params)
+    # 301, 302, 303 (only POST), 307 redirections need at least one retry for hackney to follow it.
+    make_req(:post, "session", params, 1)
   end
 
   @doc "Make capabilities for session"

--- a/notes/configuring-hound.md
+++ b/notes/configuring-hound.md
@@ -53,6 +53,11 @@ config :hound, http: [recv_timeout: :infinity, proxy: ["socks5", "127.0.0.1", "9
 ```
 
 ```elixir
+# Needed to follow 301, 302, 303 (only POST), 307 redirections
+config :hound, http: [follow_redirect: true]
+```
+
+```elixir
 # Define selenium hub settings
 config :hound,
   driver: "chrome_driver",


### PR DESCRIPTION
301, 302, 303 (only POST), 307 redirections need at least one retry for hackney to follow it.