### PR TITLE
301, 302, 303 (only POST), 307 redirections

### DIFF
--- a/lib/hound/request_utils.ex
+++ b/lib/hound/request_utils.ex
@@ -1,10 +1,8 @@
 defmodule Hound.RequestUtils do
   @moduledoc false
 
-  def make_req(type, path, params \\ %{}, options \\ %{}, retries \\ 0)
-  def make_req(type, path, params, options, 0) do
-    send_req(type, path, params, options)
-  end
+  # 301, 302, 303 (only POST), 307 redirections need at least one retry for hackney to follow it.
+  def make_req(type, path, params \\ %{}, options \\ %{}, retries \\ 1)
   def make_req(type, path, params, options, retries) do
     try do
       case send_req(type, path, params, options) do

--- a/lib/hound/session.ex
+++ b/lib/hound/session.ex
@@ -25,7 +25,6 @@ defmodule Hound.Session do
       desiredCapabilities: capabilities
     }
 
-    # No retries for this request
     make_req(:post, "session", params)
   end
 

--- a/notes/configuring-hound.md
+++ b/notes/configuring-hound.md
@@ -53,6 +53,11 @@ config :hound, http: [recv_timeout: :infinity, proxy: ["socks5", "127.0.0.1", "9
 ```
 
 ```elixir
+# Needed to follow 301, 302, 303 (only POST), 307 redirections
+config :hound, http: [follow_redirect: true]
+```
+
+```elixir
 # Define selenium hub settings
 config :hound,
   driver: "chrome_driver",


### PR DESCRIPTION
301, 302, 303 (only POST), 307 redirections need at least one retry for hackney to follow it.