### PR TITLE
Retry session

### DIFF
--- a/lib/hound/session.ex
+++ b/lib/hound/session.ex
@@ -25,8 +25,7 @@ defmodule Hound.Session do
       desiredCapabilities: capabilities
     }
 
-    # No retries for this request
-    make_req(:post, "session", params, %{}, 5)
+    make_req(:post, "session", params, %{}, 3)
   end
 
   @doc "Make capabilities for session"

--- a/lib/hound/session.ex
+++ b/lib/hound/session.ex
@@ -26,7 +26,7 @@ defmodule Hound.Session do
     }
 
     # No retries for this request
-    make_req(:post, "session", params)
+    make_req(:post, "session", params, %{}, 5)
   end
 
   @doc "Make capabilities for session"


### PR DESCRIPTION
We've found with CircleCI that we randomly received timeouts when using standalone selenium Chrome instance. 

From time to time these timeouts occur more often and seem to randomly disappear again. My suspicion is that the networking of CircleCI (I believe they use AWS) cannot be relied upon to disable the timeouts in the tests.

Is there a particular reason why the start of the session is not retried?