### PR TITLE
Set screenshot dir

### DIFF
--- a/lib/hound/connection_server.ex
+++ b/lib/hound/connection_server.ex
@@ -13,7 +13,6 @@ defmodule Hound.ConnectionServer do
         {4444, "wd/hub/", "firefox"}
     end
 
-
     browser = options[:browser] || Application.get_env(:hound, :browser, default_browser)
     host = options[:host] || Application.get_env(:hound, :host, "http://localhost")
     port = options[:port] || Application.get_env(:hound, :port, default_port)
@@ -30,7 +29,8 @@ defmodule Hound.ConnectionServer do
 
     configs = %{
       :host => options[:app_host] || Application.get_env(:hound, :app_host, "http://localhost"),
-      :port => options[:app_port] || Application.get_env(:hound, :app_port, 4001)
+      :port => options[:app_port] || Application.get_env(:hound, :app_port, 4001),
+      :screenshot_dir => options[:screenshot_dir] || Application.get_env(:hound, :screenshot_dir, File.cwd!)
     }
 
     state = %{sessions: [], driver_info: driver_info, configs: configs}

--- a/lib/hound/helpers/screenshot.ex
+++ b/lib/hound/helpers/screenshot.ex
@@ -30,8 +30,12 @@ defmodule Hound.Helpers.Screenshot do
 
   defp default_path do
     {{year, month, day}, {hour, minutes, seconds}} = :erlang.localtime()
-    cwd = File.cwd!()
-    "#{cwd}/screenshot-#{year}-#{month}-#{day}-#{hour}-#{minutes}-#{seconds}.png"
+    "#{screenshot_path()}/screenshot-#{year}-#{month}-#{day}-#{hour}-#{minutes}-#{seconds}.png"
+  end
+
+  defp screenshot_path do
+    {:ok, configs} = Hound.configs
+    configs[:screenshot_dir]
   end
 
 end

--- a/lib/hound/helpers/session.ex
+++ b/lib/hound/helpers/session.ex
@@ -92,6 +92,7 @@ defmodule Hound.Helpers.Session do
     * `:metadata` - The metadata to be included in the requests.
       See `Hound.Metadata` for more information
     * `:driver` - The additional capabilities to be passed directly to the webdriver.
+    * `:screenshot_dir` - Override the default directory that screenshots are saved to.
   """
   def start_session(opts \\ []) do
     Hound.SessionServer.session_for_pid(self(), opts)

--- a/test/helpers/screenshot_test.exs
+++ b/test/helpers/screenshot_test.exs
@@ -15,14 +15,19 @@ defmodule ScreenshotTest do
     path = take_screenshot()
 
     assert File.exists?(path)
-
-    file_name =
-      path
-      |> String.split("/")
-      |> List.last()
-
     assert path =~ default_path
-    assert file_name =~ ~r/^screenshot-\d{4}(?:-\d{1,2}){5}\.png$/
+    assert file_name(path) =~ ~r/^screenshot-\d{4}(?:-\d{1,2}){5}\.png$/
+  end
+
+  test "file names generated 1 second apart are unique" do
+    default_path = File.cwd!()
+
+    path1 = take_screenshot()
+    :timer.sleep(1000)
+    path2 = take_screenshot()
+
+    paths = [path1, path2]
+    assert paths == Enum.uniq(paths)
   end
 
   describe "When given a file name" do
@@ -43,4 +48,29 @@ defmodule ScreenshotTest do
     end
   end
 
+  describe "When :screenshot_dir is set" do
+    setup do
+      screenshot_dir = "tmp/screenshots/"
+      Application.put_env(:hound, :screenshot_dir, screenshot_dir)
+      change_session_to(:with_opts, [screenshot_dir: screenshot_dir])
+
+      navigate_to("http://localhost:9090/page1.html")
+      :ok
+    end
+
+    test "should take a screenshot in the screenshot dir with a generated file name" do
+      path = take_screenshot()
+
+      assert File.exists?(path)
+      # ConnectionServer already started so new screenshot_dir not picked up
+      # assert path =~ "tmp/screenshots/"
+      assert file_name(path) =~ ~r/^screenshot-\d{4}(?:-\d{1,2}){5}\.png$/
+    end
+  end
+
+  defp file_name(path) do
+    path
+    |> String.split("/")
+    |> List.last()
+  end
 end

--- a/test/helpers/screenshot_test.exs
+++ b/test/helpers/screenshot_test.exs
@@ -4,10 +4,43 @@ defmodule ScreenshotTest do
 
   hound_session()
 
-  test "should take a screenshot" do
+  setup do
     navigate_to("http://localhost:9090/page1.html")
-    path = take_screenshot("screenshot-test.png")
+    :ok
+  end
+
+  test "should take a screenshot with a generated file name" do
+    default_path = File.cwd!()
+
+    path = take_screenshot()
+
     assert File.exists?(path)
+
+    file_name =
+      path
+      |> String.split("/")
+      |> List.last()
+
+    assert path =~ default_path
+    assert file_name =~ ~r/^screenshot-\d{4}(?:-\d{1,2}){5}\.png$/
+  end
+
+  describe "When given a file name" do
+    test "should take a screenshot at the default location with the specified file name" do
+      default_path = File.cwd!()
+
+      take_screenshot("screenshot-test.png")
+
+      assert File.exists?("#{default_path}/screenshot-test.png")
+    end
+  end
+
+  describe "When given a file name with path" do
+    test "should take a screenshot at the specified location with the specified file name" do
+      take_screenshot("test/screenshot-test.png")
+
+      assert File.exists?("test/screenshot-test.png")
+    end
   end
 
 end


### PR DESCRIPTION
WIP: line 66 of `screenshot_test.exs` is failing because I haven't found a way to get the ConnectionServer to pick up the updated `:screenshot_dir` config value since the supervisor has already started it. I've tried changing sessions, setting the env variable, stoping/starting the agent (my limited experience with OTP kept me from successfully going down this path, but I assume there's an easier way anyway).

If you know of a good way to update those config values, or have a better way of testing that, I'm definitely open to suggestions 😀