### PR TITLE
consider the browser as well as the driver in selecting the responseparser

### DIFF
--- a/lib/hound/request_utils.ex
+++ b/lib/hound/request_utils.ex
@@ -59,14 +59,21 @@ defmodule Hound.RequestUtils do
   end
 
   defp response_parser do
-    {:ok, driver_info} = Hound.driver_info
-    case driver_info.driver do
-      "selenium" ->
-        Hound.ResponseParsers.Selenium
-      "chrome_driver" ->
+    {:ok, driver_info} = Hound.driver_info()
+
+    case {driver_info.driver, driver_info.browser} do
+      {"selenium", "chrome" <> _headless} ->
         Hound.ResponseParsers.ChromeDriver
-      "phantomjs" ->
+
+      {"selenium", _} ->
+        Hound.ResponseParsers.Selenium
+
+      {"chrome_driver", _} ->
+        Hound.ResponseParsers.ChromeDriver
+
+      {"phantomjs", _} ->
         Hound.ResponseParsers.PhantomJs
+
       other_driver ->
         raise "No response parser found for #{other_driver}"
     end


### PR DESCRIPTION
Upon upgrading selenium to its latest version (3.9.1), the NoSuchElementError is thrown by the chromedriver instead of selenium. This change selects the correct requesthandler for parsing this error to an {:error, :no_such_element} tuple.

Is there a reason for still running the older 2.48 in the tests?