### PR TITLE
deep merge options passed to hound_session

### DIFF
--- a/lib/hound/session.ex
+++ b/lib/hound/session.ex
@@ -43,7 +43,7 @@ defmodule Hound.Session do
       platform: "ANY"
     }
     |> Map.merge(Hound.Browser.make_capabilities(browser, opts))
-    |> Map.merge(opts[:driver] || %{})
+    |> deep_merge(opts[:driver] || %{})
   end
 
   @doc "Get capabilities of a particular session"
@@ -79,4 +79,12 @@ defmodule Hound.Session do
   def fetch_log_types(session_id) do
     make_req(:get, "session/#{session_id}/log/types")
   end
+
+  defp deep_merge(map1, map2) when is_map(map1) and is_map(map2) do
+    Map.merge(map1, map2, fn _k, v1, v2 ->
+      deep_merge(v1, v2)
+    end)
+  end
+
+  defp deep_merge(list1, list2), do: list1 ++ list2
 end

--- a/test/session_test.exs
+++ b/test/session_test.exs
@@ -24,4 +24,23 @@ defmodule Hound.SessionTest do
     result = Session.make_capabilities("chrome", user_agent: ua)
     assert %{chromeOptions: %{"args" => ["--user-agent=" <> ^ua]}} = result
   end
+
+  test "make_capabilities deep merges chromeOptions" do
+    %{chromeOptions: resulting_options} =
+      Session.make_capabilities(
+        "chrome_headless",
+        driver: %{
+          chromeOptions: %{
+            "args" => [
+              "--window-size=1920x1080"
+            ]
+          }
+        }
+      )
+
+    %{chromeOptions: %{"args" => default_args}} =
+      Hound.Browser.make_capabilities("chrome_headless")
+
+    assert resulting_options == %{"args" => default_args ++ ["--window-size=1920x1080"]}
+  end
 end


### PR DESCRIPTION
In case I just want to override a single `chromeOption`, I would need to redefine all arguments that are handed down to chrome. This PR adds deep_merging the options so I am able to just override or add the argument that I want, i.e. the `window_size`.