### PR TITLE
Add outer_html/1 to the Elements helper

### DIFF
--- a/lib/hound/helpers/element.ex
+++ b/lib/hound/helpers/element.ex
@@ -31,6 +31,11 @@ defmodule Hound.Helpers.Element do
   def inner_text(element) do
     attribute_value(element, "innerText")
   end
+  
+  @spec outer_html(Hound.Element.selector) :: String.t
+  def outer_html(element) do
+    attribute_value(element, "outerHTML")
+  end
 
   @doc """
   Enters value into field.


### PR DESCRIPTION
Adds a function to the elements helper to grab the outerHTML of an element

I had a need to find a given element and then return it's actual outerHTML source and not the innerHTML. I'm working around this by calling make_req directly to handle it, but this is ugly so I thought I'd throw a quick PR. Example:

```elixir
iex> elem = find_element(:css, "input[type=password]")
iex> make_req(:get, "session/#{session}/element/#{elem}/attribute/outerHTML")
"<input class=\"form-control form-control input-block\" id=\"password\" name=\"password\" tabindex=\"2\" type=\"password\">"
```