### PR TITLE
retrieve number of default retries from environment

### DIFF
--- a/lib/hound/request_utils.ex
+++ b/lib/hound/request_utils.ex
@@ -1,7 +1,9 @@
 defmodule Hound.RequestUtils do
   @moduledoc false
 
-  def make_req(type, path, params \\ %{}, options \\ %{}, retries \\ 0)
+  @retries Application.get_env(:hound, :retries, 0)
+
+  def make_req(type, path, params \\ %{}, options \\ %{}, retries \\ @retries)
   def make_req(type, path, params, options, 0) do
     send_req(type, path, params, options)
   end


### PR DESCRIPTION
Allow for the configuration of the default number of retries. This helps when there's resource starvation and you have requests failing.