### PR TITLE
Use 4002 as default app_port

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Ensure the server is started when your tests are run. In `config/test.exs` chang
 
 ```elixir
 config :hello_world_web, HelloWorldWeb.Endpoint,
-  http: [port: 4001],
+  http: [ip: {127, 0, 0, 1}, port: 4002],
   server: true
 ```
 

--- a/lib/hound/connection_server.ex
+++ b/lib/hound/connection_server.ex
@@ -30,7 +30,7 @@ defmodule Hound.ConnectionServer do
 
     configs = %{
       :host => options[:app_host] || Application.get_env(:hound, :app_host, "http://localhost"),
-      :port => options[:app_port] || Application.get_env(:hound, :app_port, 4001),
+      :port => options[:app_port] || Application.get_env(:hound, :app_port, 4002),
       :temp_dir => options[:temp_dir] || Application.get_env(:hound, :temp_dir, File.cwd!)
     }
 

--- a/notes/configuring-hound.md
+++ b/notes/configuring-hound.md
@@ -38,8 +38,8 @@ config :hound, driver: "phantomjs", host: "http://example.com", port: 5555
 ```
 
 ```elixir
-# Define your application's host and port (defaults to "http://localhost:4001")
-config :hound, app_host: "http://localhost", app_port: 4001
+# Define your application's host and port (defaults to "http://localhost:4002")
+config :hound, app_host: "http://localhost", app_port: 4002
 ```
 
 ```elixir


### PR DESCRIPTION
Not sure if this would be a welcomed change. I noticed that hound assumes the app runs on port 4001. I assume this was done to match phoenix default port in test env. Phoenix uses port 4002 since https://github.com/phoenixframework/phoenix/pull/3110

Alternatively, the setup docs could be updated to say that both `server` and `port` have to be changed in `config/test.exs`, or that the `app_port` has to be specified. I'd be happy to change this PR to update only the docs if that is preferred.

Thank you for maintaining this 💜 