### PR TITLE
Fix most impactful Elixir 1.17 warnings

### DIFF
--- a/lib/hound/browser.ex
+++ b/lib/hound/browser.ex
@@ -13,7 +13,7 @@ defmodule Hound.Browser do
     browser = browser(browser_name)
 
     user_agent =
-      user_agent(opts[:user_agent] || browser.default_user_agent)
+      user_agent(opts[:user_agent] || browser.default_user_agent())
       |> Hound.Metadata.append(opts[:metadata])
 
     capabilities = %{browserName: browser_name}

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Hound.Mixfile do
     [
       extra_applications: [:logger],
       mod: {Hound, []},
-      description: 'Integration testing and browser automation library',
+      description: ~c"Integration testing and browser automation library",
     ]
   end
 


### PR DESCRIPTION
In 825f3a9b1c5fd1220ff2d043e5ad5c5765916901 I've fixed a warning about invoking a function without parentheses. It shows at run-time and looks like this:

```
warning: using map.field notation (without parentheses) to invoke function Hound.Browser.ChromeHeadless.default_user_agent() is deprecated, you must add parentheses instead: remote.function()
  (hound 1.1.1) lib/hound/browser.ex:16: Hound.Browser.make_capabilities/2
  (hound 1.1.1) lib/hound/session.ex:45: Hound.Session.make_capabilities/2
  (hound 1.1.1) lib/hound/session.ex:23: Hound.Session.create_session/2
  (hound 1.1.1) lib/hound/session_server.ex:99: Hound.SessionServer.create_session/2
  (hound 1.1.1) lib/hound/session_server.ex:78: Hound.SessionServer.handle_call/3
  (stdlib 6.0) gen_server.erl:2209: :gen_server.try_handle_call/4
  (stdlib 6.0) gen_server.erl:2238: :gen_server.handle_msg/6
  (stdlib 6.0) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
```

While at it, because of https://github.com/elixir-lang/elixir/issues/13132 , in 074c84116e134c1afc9b92749a8d5f99141ce001 I've also fixed another warning in the mix.exs file